### PR TITLE
extended pippenger block size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(TESTING "Build tests" ON)
 option(BENCHMARKS "Build benchmarks" ON)
 option(PROFILING "Build profiling" ON)
 option(FORCE_CLANG "force build with clang" OFF) # OFF is the default
+option(PIPPENGER_BLOCK_SIZE "maximum multi-exponentiation size" "20")
 
 if (ARM)
     set(DISABLE_ASM ON)
@@ -115,6 +116,13 @@ endif()
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-float-conversion -Wimplicit-fallthrough=0")
 endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy -Wno-tautological-compare")
+
+
+message(STATUS "Setting pippenger block size to " ${PIPPENGER_BLOCK_SIZE})
+add_definitions(-DPIPPENGER_BLOCK_SIZE=${PIPPENGER_BLOCK_SIZE})
+
 
 add_definitions(-DBOOST_SPIRIT_X3_NO_FILESYSTEM=1 -DBARRETENBERG_SRS_PATH=\"../srs_db/transcript.dat\")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(TESTING "Build tests" ON)
 option(BENCHMARKS "Build benchmarks" ON)
 option(PROFILING "Build profiling" ON)
 option(FORCE_CLANG "force build with clang" OFF) # OFF is the default
-option(PIPPENGER_BLOCK_SIZE "maximum multi-exponentiation size" "20")
+SET(PIPPENGER_BLOCK_SIZE "20" CACHE STRING "maximum multi-exponentiation size")
 
 if (ARM)
     set(DISABLE_ASM ON)

--- a/src/barretenberg/curves/bn254/scalar_multiplication/mmu.cpp
+++ b/src/barretenberg/curves/bn254/scalar_multiplication/mmu.cpp
@@ -14,10 +14,12 @@ static uint32_t* bit_count_memory = nullptr;
 static bool* bucket_empty_status = nullptr;
 
 const auto init = []() {
-    printf("init...\n");
-    constexpr size_t max_num_points = (1 << 20);
+    printf("init. pippenger block size = %d\n", PIPPENGER_BLOCK_SIZE);
+    static_assert(PIPPENGER_BLOCK_SIZE < 27);
+    constexpr size_t max_num_points = (1 << PIPPENGER_BLOCK_SIZE);
     constexpr size_t max_num_rounds = 8;
-    constexpr size_t max_buckets = 1 << 15;
+    constexpr size_t max_buckets =
+        1 << barretenberg::scalar_multiplication::get_optimal_bucket_width(1 << PIPPENGER_BLOCK_SIZE);
     constexpr size_t thread_overspill = 1024;
 
     // size_t memory = max_num_points * max_num_rounds * 2 * sizeof(uint64_t);
@@ -77,7 +79,7 @@ g1::element* get_bucket_pointer()
 scalar_multiplication::affine_product_runtime_state get_affine_product_runtime_state(const size_t num_threads,
                                                                                      const size_t thread_index)
 {
-    constexpr size_t max_num_points = (2 << 20);
+    constexpr size_t max_num_points = (2 << PIPPENGER_BLOCK_SIZE);
     const size_t points_per_thread = max_num_points / num_threads;
 
     scalar_multiplication::affine_product_runtime_state product_state;

--- a/src/barretenberg/curves/bn254/scalar_multiplication/mmu.hpp
+++ b/src/barretenberg/curves/bn254/scalar_multiplication/mmu.hpp
@@ -1,12 +1,62 @@
 #pragma once
 
 #include "../g1.hpp"
+#include "../../../types.hpp"
 
 namespace barretenberg
 {
 // simple helper functions to retrieve pointers to pre-allocated memory for the scalar multiplication algorithm.
 // This is to eliminate page faults when allocating (and writing) to large tranches of memory.
 namespace scalar_multiplication {
+constexpr size_t get_optimal_bucket_width(const size_t num_points)
+{
+    if (num_points >= 14617149) {
+        return 21;
+    }
+    if (num_points >= 1139094) {
+        return 18;
+    }
+    // if (num_points >= 100000)
+    if (num_points >= 155975) {
+        return 15;
+    }
+    if (num_points >= 144834)
+    // if (num_points >= 100000)
+    {
+        return 14;
+    }
+    if (num_points >= 25067) {
+        return 12;
+    }
+    if (num_points >= 13926) {
+        return 11;
+    }
+    if (num_points >= 7659) {
+        return 10;
+    }
+    if (num_points >= 2436) {
+        return 9;
+    }
+    if (num_points >= 376) {
+        return 7;
+    }
+    if (num_points >= 231) {
+        return 6;
+    }
+    if (num_points >= 97) {
+        return 5;
+    }
+    if (num_points >= 35) {
+        return 4;
+    }
+    if (num_points >= 10) {
+        return 3;
+    }
+    if (num_points >= 2) {
+        return 2;
+    }
+    return 1;
+}
 struct affine_product_runtime_state {
     g1::affine_element* points;
     g1::affine_element* point_pairs_1;

--- a/src/barretenberg/curves/bn254/scalar_multiplication/scalar_multiplication.cpp
+++ b/src/barretenberg/curves/bn254/scalar_multiplication/scalar_multiplication.cpp
@@ -619,6 +619,7 @@ inline g1::element pippenger(fr::field_t* scalars, g1::affine_element* points, c
  **/
 g1::element pippenger_unsafe(fr::field_t* scalars, g1::affine_element* points, const size_t num_initial_points)
 {
+    static_assert(PIPPENGER_BLOCK_SIZE <= 26);
     // our windowed non-adjacent form algorthm requires that each thread can work on at least 8 points.
     // If we fall below this theshold, fall back to the traditional scalar multiplication algorithm.
     // For 8 threads, this neatly coincides with the threshold where Strauss scalar multiplication outperforms Pippenger
@@ -652,10 +653,41 @@ g1::element pippenger_unsafe(fr::field_t* scalars, g1::affine_element* points, c
     }
 
     const size_t log2_initial_points =
-        std::min(static_cast<size_t>(internal::get_msb(static_cast<uint32_t>(num_initial_points))), 20UL);
+        std::min(static_cast<size_t>(internal::get_msb(static_cast<uint32_t>(num_initial_points))),
+                 static_cast<size_t>(PIPPENGER_BLOCK_SIZE));
     g1::element result;
 
     switch (log2_initial_points) {
+#if PIPPENGER_BLOCK_SIZE > 25
+    case 26:
+        result = pippenger_unsafe_internal<1 << 26>(points, scalars);
+        break;
+#endif
+#if PIPPENGER_BLOCK_SIZE > 24
+    case 25:
+        result = pippenger_unsafe_internal<1 << 25>(points, scalars);
+        break;
+#endif
+#if PIPPENGER_BLOCK_SIZE > 23
+    case 24:
+        result = pippenger_unsafe_internal<1 << 24>(points, scalars);
+        break;
+#endif
+#if PIPPENGER_BLOCK_SIZE > 22
+    case 23:
+        result = pippenger_unsafe_internal<1 << 23>(points, scalars);
+        break;
+#endif
+#if PIPPENGER_BLOCK_SIZE > 21
+    case 22:
+        result = pippenger_unsafe_internal<1 << 22>(points, scalars);
+        break;
+#endif
+#if PIPPENGER_BLOCK_SIZE > 20
+    case 21:
+        result = pippenger_unsafe_internal<1 << 21>(points, scalars);
+        break;
+#endif
     case 20:
         result = pippenger_unsafe_internal<1 << 20>(points, scalars);
         break;
@@ -762,6 +794,43 @@ template g1::element scalar_multiplication_internal<1 << 19>(multiplication_runt
                                                              g1::affine_element* points);
 template g1::element scalar_multiplication_internal<1 << 20>(multiplication_runtime_state& state,
                                                              g1::affine_element* points);
+
+#if PIPPENGER_BLOCK_SIZE > 25
+template g1::element scalar_multiplication_internal<1 << 26>(multiplication_runtime_state& state,
+                                                             g1::affine_element* points);
+template void compute_wnaf_states<1 << 26>(multiplication_runtime_state& state, fr::field_t* scalars);
+template void organize_buckets<1 << 27>(multiplication_runtime_state& state);
+#endif
+#if PIPPENGER_BLOCK_SIZE > 24
+template g1::element scalar_multiplication_internal<1 << 25>(multiplication_runtime_state& state,
+                                                             g1::affine_element* points);
+template void compute_wnaf_states<1 << 25>(multiplication_runtime_state& state, fr::field_t* scalars);
+template void organize_buckets<1 << 26>(multiplication_runtime_state& state);
+#endif
+#if PIPPENGER_BLOCK_SIZE > 23
+template g1::element scalar_multiplication_internal<1 << 24>(multiplication_runtime_state& state,
+                                                             g1::affine_element* points);
+template void compute_wnaf_states<1 << 24>(multiplication_runtime_state& state, fr::field_t* scalars);
+template void organize_buckets<1 << 25>(multiplication_runtime_state& state);
+#endif
+#if PIPPENGER_BLOCK_SIZE > 22
+template g1::element scalar_multiplication_internal<1 << 23>(multiplication_runtime_state& state,
+                                                             g1::affine_element* points);
+template void compute_wnaf_states<1 << 23>(multiplication_runtime_state& state, fr::field_t* scalars);
+template void organize_buckets<1 << 24>(multiplication_runtime_state& state);
+#endif
+#if PIPPENGER_BLOCK_SIZE > 21
+template g1::element scalar_multiplication_internal<1 << 22>(multiplication_runtime_state& state,
+                                                             g1::affine_element* points);
+template void compute_wnaf_states<1 << 22>(multiplication_runtime_state& state, fr::field_t* scalars);
+template void organize_buckets<1 << 23>(multiplication_runtime_state& state);
+#endif
+#if PIPPENGER_BLOCK_SIZE > 20
+template g1::element scalar_multiplication_internal<1 << 21>(multiplication_runtime_state& state,
+                                                             g1::affine_element* points);
+template void compute_wnaf_states<1 << 21>(multiplication_runtime_state& state, fr::field_t* scalars);
+template void organize_buckets<1 << 22>(multiplication_runtime_state& state);
+#endif
 
 template void compute_wnaf_states<1 << 2>(multiplication_runtime_state& state, fr::field_t* scalars);
 template void compute_wnaf_states<1 << 3>(multiplication_runtime_state& state, fr::field_t* scalars);

--- a/src/barretenberg/curves/bn254/scalar_multiplication/scalar_multiplication.hpp
+++ b/src/barretenberg/curves/bn254/scalar_multiplication/scalar_multiplication.hpp
@@ -3,16 +3,13 @@
 #include "../../../types.hpp"
 #include "../fr.hpp"
 #include "../g1.hpp"
+#include "./mmu.hpp"
 #include <stddef.h>
 #include <stdint.h>
-#include "./mmu.hpp"
 
-namespace barretenberg
-{
-namespace scalar_multiplication
-{
-namespace internal
-{
+namespace barretenberg {
+namespace scalar_multiplication {
+namespace internal {
 // from http://supertech.csail.mit.edu/papers/debruijn.pdf
 constexpr size_t get_msb(const uint32_t v)
 {
@@ -48,55 +45,6 @@ constexpr uint32_t get_msb_32(const uint32_t v)
 }
 } // namespace internal
 
-constexpr size_t get_optimal_bucket_width(const size_t num_points)
-{
-    if (num_points >= 14617149) {
-        return 21;
-    }
-    if (num_points >= 2139094) {
-        return 18;
-    }
-    // if (num_points >= 100000)
-    if (num_points >= 155975) {
-        return 15;
-    }
-    if (num_points >= 144834)
-    // if (num_points >= 100000)
-    {
-        return 14;
-    }
-    if (num_points >= 25067) {
-        return 12;
-    }
-    if (num_points >= 13926) {
-        return 11;
-    }
-    if (num_points >= 7659) {
-        return 10;
-    }
-    if (num_points >= 2436) {
-        return 9;
-    }
-    if (num_points >= 376) {
-        return 7;
-    }
-    if (num_points >= 231) {
-        return 6;
-    }
-    if (num_points >= 97) {
-        return 5;
-    }
-    if (num_points >= 35) {
-        return 4;
-    }
-    if (num_points >= 10) {
-        return 3;
-    }
-    if (num_points >= 2) {
-        return 2;
-    }
-    return 1;
-}
 
 constexpr size_t get_num_buckets(const size_t num_points)
 {
@@ -114,89 +62,89 @@ constexpr size_t get_num_rounds(const size_t num_points)
  * `wnaf_table` is an unrolled two-dimensional array, with each inner array being of size `n`,
  * where `n` is the number of points being multiplied. The second dimension size is defined by
  * the number of pippenger rounds (fixed for a given `n`, see `get_num_rounds`)
- * 
+ *
  * An entry of `wnaf_table` contains the following three pieces of information:
  * 1: the point index that we're working on. This is stored in the high 32 bits
  * 2: the bucket index that we're adding the point into. This is stored in the low 31 bits
  * 3: the sign of the point we're adding (i.e. do we actually need to subtract). This is stored in the 32nd bit.
- * 
+ *
  * We pack this information into a 64 bit unsigned integer, so that we can more efficiently sort our wnaf entries.
  * For a given round, we want to sort our wnaf entries in increasing bucket index order.
- * 
+ *
  * This is so that we can efficiently use multiple threads to execute the pippenger algorithm.
  * For a given round, a given point's bucket index will be uniformly randomly distributed,
- * assuming the inputs are from a zero-knowledge proof. This is because the scalar multiplier will be uniformly randomly distributed,
- * and the bucket indices are derived from the scalar multiplier.
- * 
- * This means that, if we were to iterate over all of our points in order, and add each point into its associated bucket,
- * we would be accessing all of our buckets in a completely random pattern.
- * 
- * Aside from memory latency problems this incurs, this makes the naive algorithm unsuitable for multithreading - we cannot
- * assign a thread a tranche of points, because each thread will be adding points into the same set of buckets, triggering race conditions.
- * We do not want to manage the overhead of thread locks for each bucket; the process of adding a point into a bucket takes,
- * on average, only 400 CPU cycles, so the slowdown of managing mutex locks would add considerable overhead.
- * 
- * The solution is to sort the buckets. If the buckets are sorted, we can assign a tranche of buckets to individual threads,
- * safe in the knowledge that there will be no race conditions, with one condition.
- * A thread's starting bucket may be equal to the previous thread's end bucket, so we need to ensure that each thread works on
- * a local array of buckets. This adds little overhead (for 2^20 points, we have 32,768 buckets. With 8 threads, the amount of bucket overlap
- * is ~16 buckets, so we could incur 16 extra 'additions' in pippenger's bucket concatenation phase, but this is an insignificant contribution).
- * 
- * The alternative approach (the one we used to use) is to slice up all of the points being multiplied amongst all available threads,
- * and run the complete pippenger algorithm for each thread. This is suboptimal, because the complexity of pippenger is O(n / logn) point additions,
- * and a sequence of smaller pippenger calls will have a smaller `n`.
- * 
- * This is the motivation for multi-threading the actual Pippenger algorithm. In addition, the above approach performs extremely poorly
- * for GPUs, where the number of threads can be as high as 2^10
- * (for a multi-scalar-multiplication of 2^20 points, this doubles the number of pippenger rounds per thread)
- * 
- * To give concrete numbers, the difference between calling pippenger on 2^20 points, and calling pippenger 8 times on 2^17 points,
- * is 5-10%. Which means that, for 8 threads, we need to ensure that our sorting algorithm adds less than 5% to the total runtime of pippenger.
- * Given a single cache miss per point would increase the run-time by 25%, this is not much room to work with!
- * 
- * However, a radix sort, combined with the fact that the total number of buckets is quite small (2^16 at most), seems to be fast enough.
- * Benchmarks indicate (i7-8650U, 8 threads) that, for 2^20 points, the total runtime is <1200ms and of that, the radix sort consumes 58ms (4.8%)
- * 
- * One advantage of sorting by bucket order vs point order, is that a 'bucket' is 96 bytes large (sizeof(g1::element), buckets have z-coordinates).
- * Points, on the other hand, are 64 bytes large (affine points, no z-coordinate).
- * This makes fetching random point locations in memory more efficient than fetching random bucket locations, as each point occupies a single cache line.
- * Using __builtin_prefetch to recover the point just before it's needed, seems to improve the runtime of pippenger by 10-20%.
- * 
+ * assuming the inputs are from a zero-knowledge proof. This is because the scalar multiplier will be uniformly randomly
+ *distributed, and the bucket indices are derived from the scalar multiplier.
+ *
+ * This means that, if we were to iterate over all of our points in order, and add each point into its associated
+ *bucket, we would be accessing all of our buckets in a completely random pattern.
+ *
+ * Aside from memory latency problems this incurs, this makes the naive algorithm unsuitable for multithreading - we
+ *cannot assign a thread a tranche of points, because each thread will be adding points into the same set of buckets,
+ *triggering race conditions. We do not want to manage the overhead of thread locks for each bucket; the process of
+ *adding a point into a bucket takes, on average, only 400 CPU cycles, so the slowdown of managing mutex locks would add
+ *considerable overhead.
+ *
+ * The solution is to sort the buckets. If the buckets are sorted, we can assign a tranche of buckets to individual
+ *threads, safe in the knowledge that there will be no race conditions, with one condition. A thread's starting bucket
+ *may be equal to the previous thread's end bucket, so we need to ensure that each thread works on a local array of
+ *buckets. This adds little overhead (for 2^20 points, we have 32,768 buckets. With 8 threads, the amount of bucket
+ *overlap is ~16 buckets, so we could incur 16 extra 'additions' in pippenger's bucket concatenation phase, but this is
+ *an insignificant contribution).
+ *
+ * The alternative approach (the one we used to use) is to slice up all of the points being multiplied amongst all
+ *available threads, and run the complete pippenger algorithm for each thread. This is suboptimal, because the
+ *complexity of pippenger is O(n / logn) point additions, and a sequence of smaller pippenger calls will have a smaller
+ *`n`.
+ *
+ * This is the motivation for multi-threading the actual Pippenger algorithm. In addition, the above approach performs
+ *extremely poorly for GPUs, where the number of threads can be as high as 2^10 (for a multi-scalar-multiplication of
+ *2^20 points, this doubles the number of pippenger rounds per thread)
+ *
+ * To give concrete numbers, the difference between calling pippenger on 2^20 points, and calling pippenger 8 times on
+ *2^17 points, is 5-10%. Which means that, for 8 threads, we need to ensure that our sorting algorithm adds less than 5%
+ *to the total runtime of pippenger. Given a single cache miss per point would increase the run-time by 25%, this is not
+ *much room to work with!
+ *
+ * However, a radix sort, combined with the fact that the total number of buckets is quite small (2^16 at most), seems
+ *to be fast enough. Benchmarks indicate (i7-8650U, 8 threads) that, for 2^20 points, the total runtime is <1200ms and
+ *of that, the radix sort consumes 58ms (4.8%)
+ *
+ * One advantage of sorting by bucket order vs point order, is that a 'bucket' is 96 bytes large (sizeof(g1::element),
+ *buckets have z-coordinates). Points, on the other hand, are 64 bytes large (affine points, no z-coordinate). This
+ *makes fetching random point locations in memory more efficient than fetching random bucket locations, as each point
+ *occupies a single cache line. Using __builtin_prefetch to recover the point just before it's needed, seems to improve
+ *the runtime of pippenger by 10-20%.
+ *
  * Finally, `skew_table` tracks whether a scalar multplier is even or odd
  * (if it's even, we need to subtract the point from the total result,
  * because our windowed non-adjacent form values can only be odd)
- * 
+ *
  **/
-struct multiplication_runtime_state
-{
+struct multiplication_runtime_state {
     uint64_t* wnaf_table;
     bool* skew_table;
 };
 
-struct multiplication_thread_state
-{
+struct multiplication_thread_state {
     g1::element* buckets;
     const uint64_t* point_schedule;
 };
-
 
 template <size_t num_initial_points>
 void compute_wnaf_states(multiplication_runtime_state& state, fr::field_t* scalars);
 
 void generate_pippenger_point_table(g1::affine_element* points, g1::affine_element* table, size_t num_points);
 
-
 template <size_t num_points> void organize_buckets(multiplication_runtime_state& state);
 
 void scalar_multiplication_round_inner(multiplication_thread_state& state,
-                                                 const size_t num_points,
-                                                 const uint64_t bucket_offset,
-                                                 g1::affine_element* points);
-
+                                       const size_t num_points,
+                                       const uint64_t bucket_offset,
+                                       g1::affine_element* points);
 
 template <size_t num_points>
-g1::element scalar_multiplication_internal(multiplication_runtime_state& state,
-                                                     g1::affine_element* points);
+g1::element scalar_multiplication_internal(multiplication_runtime_state& state, g1::affine_element* points);
 
 g1::element pippenger(fr::field_t* scalars, g1::affine_element* points, const size_t num_points);
 
@@ -205,17 +153,14 @@ g1::element pippenger_unsafe(fr::field_t* scalars, g1::affine_element* points, c
 template <size_t num_bits>
 inline void count_bits(uint32_t* bucket_counts, uint32_t* bit_offsets, const uint32_t num_buckets)
 {
-    for (size_t i = 0; i < num_buckets; ++i)
-    {
+    for (size_t i = 0; i < num_buckets; ++i) {
         const uint32_t count = bucket_counts[i];
-        for (uint32_t j = 0; j < num_bits; ++j)
-        {
-            bit_offsets[j + 1] += (count & (1U << j));//((count >> j) & 0x01U);
+        for (uint32_t j = 0; j < num_bits; ++j) {
+            bit_offsets[j + 1] += (count & (1U << j)); //((count >> j) & 0x01U);
         }
     }
     bit_offsets[0] = 0;
-    for (size_t i = 2; i < num_bits + 1; ++i)
-    {
+    for (size_t i = 2; i < num_bits + 1; ++i) {
         bit_offsets[i] += bit_offsets[i - 1];
     }
 }
@@ -228,25 +173,44 @@ void evaluate_addition_chains(affine_product_runtime_state& state, const size_t 
 
 g1::affine_element* reduce_buckets(affine_product_runtime_state& state, bool first_round = true);
 
-extern template g1::element scalar_multiplication_internal<1 << 2>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 3>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 4>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 5>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 6>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 7>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 8>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 9>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 10>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 11>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 12>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 13>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 14>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 15>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 16>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 17>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 18>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 19>(multiplication_runtime_state& state, g1::affine_element* points);
-extern template g1::element scalar_multiplication_internal<1 << 20>(multiplication_runtime_state& state, g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 2>(multiplication_runtime_state& state,
+                                                                   g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 3>(multiplication_runtime_state& state,
+                                                                   g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 4>(multiplication_runtime_state& state,
+                                                                   g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 5>(multiplication_runtime_state& state,
+                                                                   g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 6>(multiplication_runtime_state& state,
+                                                                   g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 7>(multiplication_runtime_state& state,
+                                                                   g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 8>(multiplication_runtime_state& state,
+                                                                   g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 9>(multiplication_runtime_state& state,
+                                                                   g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 10>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 11>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 12>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 13>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 14>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 15>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 16>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 17>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 18>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 19>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
+extern template g1::element scalar_multiplication_internal<1 << 20>(multiplication_runtime_state& state,
+                                                                    g1::affine_element* points);
 
 extern template void compute_wnaf_states<1 << 2>(multiplication_runtime_state& state, fr::field_t* scalars);
 extern template void compute_wnaf_states<1 << 3>(multiplication_runtime_state& state, fr::field_t* scalars);
@@ -291,4 +255,3 @@ extern template void organize_buckets<1 << 21>(multiplication_runtime_state& sta
 
 } // namespace scalar_multiplication
 } // namespace barretenberg
-

--- a/src/barretenberg/types.hpp
+++ b/src/barretenberg/types.hpp
@@ -28,6 +28,9 @@
 #define USE_AVX 1
 #endif
 
+#ifndef PIPPENGER_BLOCK_SIZE
+#define PIPPENGER_BLOCK_SIZE 20
+#endif
 // void foo(const evaluation_domain& domain)
 // {
 //     std::vector<std::thread> threads(domain.thread_size);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 # barretenberg
 # copyright 2019 Spilsbury Holdings
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy")
+
 add_definitions(-DGTEST_HAS_EXCEPTIONS=0)
 if(WASM)
     add_definitions(-DGTEST_HAS_STREAM_REDIRECTION=0)


### PR DESCRIPTION
having a max multi-exp size of 2^20 is insufficient for large circuits.

compile time parameter -DPIPPENGER_BLOCK_SIZE=X can be used
to extend the block size of 2^26 

parameter X is log2(num points) 

e.g. cmake .. -DPIPPENGER_BLOCK_SIZE=26