### PR TITLE
Randomized constraints

### DIFF
--- a/barretenberg/src/aztec/ecc/curves/bn254/fq.test.cpp
+++ b/barretenberg/src/aztec/ecc/curves/bn254/fq.test.cpp
@@ -1,7 +1,6 @@
 #include "fq.hpp"
 #include "pseudorandom.hpp"
 #include <gtest/gtest.h>
-#include <sys/random.h>
 
 using namespace barretenberg;
 
@@ -344,12 +343,7 @@ TEST(fq, neg)
 
 TEST(fq, split_into_endomorphism_scalars)
 {
-    fq input = 0;
-    int got_entropy = getentropy((void*)&input.data[0], 32);
-    EXPECT_EQ(got_entropy, 0);
-    input.data[3] &= 0x0fffffffffffffff;
-
-    fq k = { input.data[0], input.data[1], input.data[2], input.data[3] };
+    fq k = fq::random_element();
     fq k1 = 0;
     fq k2 = 0;
 

--- a/barretenberg/src/aztec/ecc/curves/bn254/fr.test.cpp
+++ b/barretenberg/src/aztec/ecc/curves/bn254/fr.test.cpp
@@ -1,6 +1,5 @@
 #include "fr.hpp"
 #include <gtest/gtest.h>
-#include <sys/random.h>
 
 using namespace barretenberg;
 
@@ -254,12 +253,7 @@ TEST(fr, neg)
 
 TEST(fr, split_into_endomorphism_scalars)
 {
-    fr input = { 0, 0, 0, 0 };
-    int got_entropy = getentropy((void*)&input.data[0], 32);
-    EXPECT_EQ(got_entropy, 0);
-    input.data[3] &= 0x0fffffffffffffff;
-
-    fr k = { input.data[0], input.data[1], input.data[2], input.data[3] };
+    fr k = fr::random_element();
     fr k1 = { 0, 0, 0, 0 };
     fr k2 = { 0, 0, 0, 0 };
 

--- a/barretenberg/src/aztec/ecc/fields/field_impl_generic.hpp
+++ b/barretenberg/src/aztec/ecc/fields/field_impl_generic.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 namespace barretenberg {
+
+// constexpr void mac_wasm(const uint64_t a, const uint64_t b, const uint64_t c, const uint64_t carr)
+
 template <class T>
 constexpr std::pair<uint64_t, uint64_t> field<T>::mul_wide(const uint64_t a, const uint64_t b) noexcept
 {

--- a/barretenberg/src/aztec/ecc/groups/affine_element.hpp
+++ b/barretenberg/src/aztec/ecc/groups/affine_element.hpp
@@ -54,7 +54,7 @@ template <typename Fq, typename Fr, typename Params> class alignas(64) affine_el
         return result;
     }
 
-    inline std::vector<uint8_t> to_buffer()
+    inline std::vector<uint8_t> to_buffer() const
     {
         std::vector<uint8_t> buffer(sizeof(affine_element));
         affine_element::serialize_to_buffer(*this, &buffer[0]);

--- a/barretenberg/src/aztec/plonk/composer/mimc_composer.cpp
+++ b/barretenberg/src/aztec/plonk/composer/mimc_composer.cpp
@@ -3,6 +3,7 @@
 #include <numeric/bitop/get_msb.hpp>
 #include <plonk/proof_system/widgets/arithmetic_widget.hpp>
 #include <plonk/proof_system/widgets/mimc_widget.hpp>
+#include <plonk/proof_system/widgets/permutation_widget.hpp>
 
 using namespace barretenberg;
 
@@ -399,11 +400,14 @@ Prover MiMCComposer::preprocess()
     compute_witness();
     Prover output_state(circuit_proving_key, witness, create_manifest(public_inputs.size()));
 
+    std::unique_ptr<ProverPermutationWidget<3>> permutation_widget =
+        std::make_unique<ProverPermutationWidget<3>>(circuit_proving_key.get(), witness.get());
     std::unique_ptr<ProverMiMCWidget> mimc_widget =
         std::make_unique<ProverMiMCWidget>(circuit_proving_key.get(), witness.get());
     std::unique_ptr<ProverArithmeticWidget> arithmetic_widget =
         std::make_unique<ProverArithmeticWidget>(circuit_proving_key.get(), witness.get());
 
+    output_state.widgets.emplace_back(std::move(permutation_widget));
     output_state.widgets.emplace_back(std::move(arithmetic_widget));
     output_state.widgets.emplace_back(std::move(mimc_widget));
     return output_state;

--- a/barretenberg/src/aztec/plonk/composer/standard_composer.cpp
+++ b/barretenberg/src/aztec/plonk/composer/standard_composer.cpp
@@ -2,6 +2,7 @@
 #include <ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp>
 #include <numeric/bitop/get_msb.hpp>
 #include <plonk/proof_system/widgets/arithmetic_widget.hpp>
+#include <plonk/proof_system/widgets/permutation_widget.hpp>
 
 using namespace barretenberg;
 
@@ -743,9 +744,13 @@ UnrolledProver StandardComposer::create_unrolled_prover()
     compute_proving_key();
     compute_witness();
     UnrolledProver output_state(circuit_proving_key, witness, create_unrolled_manifest(public_inputs.size()));
+
+    std::unique_ptr<ProverPermutationWidget<3>> permutation_widget =
+        std::make_unique<ProverPermutationWidget<3>>(circuit_proving_key.get(), witness.get());
     std::unique_ptr<ProverArithmeticWidget> widget =
         std::make_unique<ProverArithmeticWidget>(circuit_proving_key.get(), witness.get());
 
+    output_state.widgets.emplace_back(std::move(permutation_widget));
     output_state.widgets.emplace_back(std::move(widget));
 
     return output_state;
@@ -757,9 +762,12 @@ Prover StandardComposer::preprocess()
     compute_witness();
     Prover output_state(circuit_proving_key, witness, create_manifest(public_inputs.size()));
 
+    std::unique_ptr<ProverPermutationWidget<3>> permutation_widget =
+        std::make_unique<ProverPermutationWidget<3>>(circuit_proving_key.get(), witness.get());
     std::unique_ptr<ProverArithmeticWidget> widget =
         std::make_unique<ProverArithmeticWidget>(circuit_proving_key.get(), witness.get());
 
+    output_state.widgets.emplace_back(std::move(permutation_widget));
     output_state.widgets.emplace_back(std::move(widget));
     return output_state;
 }

--- a/barretenberg/src/aztec/plonk/composer/turbo_composer.cpp
+++ b/barretenberg/src/aztec/plonk/composer/turbo_composer.cpp
@@ -1164,6 +1164,8 @@ UnrolledTurboProver TurboComposer::create_unrolled_prover()
 
     UnrolledTurboProver output_state(circuit_proving_key, witness, create_unrolled_manifest(public_inputs.size()));
 
+    std::unique_ptr<ProverPermutationWidget<4>> permutation_widget =
+        std::make_unique<ProverPermutationWidget<4>>(circuit_proving_key.get(), witness.get());
     std::unique_ptr<ProverTurboFixedBaseWidget> fixed_base_widget =
         std::make_unique<ProverTurboFixedBaseWidget>(circuit_proving_key.get(), witness.get());
     std::unique_ptr<ProverTurboRangeWidget> range_widget =
@@ -1171,6 +1173,7 @@ UnrolledTurboProver TurboComposer::create_unrolled_prover()
     std::unique_ptr<ProverTurboLogicWidget> logic_widget =
         std::make_unique<ProverTurboLogicWidget>(circuit_proving_key.get(), witness.get());
 
+    output_state.widgets.emplace_back(std::move(permutation_widget));
     output_state.widgets.emplace_back(std::move(fixed_base_widget));
     output_state.widgets.emplace_back(std::move(range_widget));
     output_state.widgets.emplace_back(std::move(logic_widget));

--- a/barretenberg/src/aztec/plonk/composer/turbo_composer.cpp
+++ b/barretenberg/src/aztec/plonk/composer/turbo_composer.cpp
@@ -1,6 +1,7 @@
 #include "turbo_composer.hpp"
 #include <ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp>
 #include <numeric/bitop/get_msb.hpp>
+#include <plonk/proof_system/widgets/permutation_widget.hpp>
 #include <plonk/proof_system/widgets/turbo_arithmetic_widget.hpp>
 #include <plonk/proof_system/widgets/turbo_fixed_base_widget.hpp>
 #include <plonk/proof_system/widgets/turbo_logic_widget.hpp>
@@ -1139,6 +1140,8 @@ TurboProver TurboComposer::create_prover()
 
     TurboProver output_state(circuit_proving_key, witness, create_manifest(public_inputs.size()));
 
+    std::unique_ptr<ProverPermutationWidget<4>> permutation_widget =
+        std::make_unique<ProverPermutationWidget<4>>(circuit_proving_key.get(), witness.get());
     std::unique_ptr<ProverTurboFixedBaseWidget> fixed_base_widget =
         std::make_unique<ProverTurboFixedBaseWidget>(circuit_proving_key.get(), witness.get());
     std::unique_ptr<ProverTurboRangeWidget> range_widget =
@@ -1146,6 +1149,7 @@ TurboProver TurboComposer::create_prover()
     std::unique_ptr<ProverTurboLogicWidget> logic_widget =
         std::make_unique<ProverTurboLogicWidget>(circuit_proving_key.get(), witness.get());
 
+    output_state.widgets.emplace_back(std::move(permutation_widget));
     output_state.widgets.emplace_back(std::move(fixed_base_widget));
     output_state.widgets.emplace_back(std::move(range_widget));
     output_state.widgets.emplace_back(std::move(logic_widget));

--- a/barretenberg/src/aztec/plonk/proof_system/prover/prover.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/prover/prover.cpp
@@ -476,6 +476,13 @@ template <typename settings> barretenberg::fr ProverBase<settings>::compute_line
     return t_eval;
 }
 
+template <typename settings> waffle::plonk_proof ProverBase<settings>::export_proof()
+{
+    waffle::plonk_proof result;
+    result.proof_data = transcript.export_transcript();
+    return result;
+}
+
 template <typename settings> waffle::plonk_proof ProverBase<settings>::construct_proof()
 {
     execute_preamble_round();
@@ -489,10 +496,7 @@ template <typename settings> waffle::plonk_proof ProverBase<settings>::construct
     execute_fourth_round();
     execute_fifth_round();
     queue.process_queue();
-
-    waffle::plonk_proof result;
-    result.proof_data = transcript.export_transcript();
-    return result;
+    return export_proof();
 }
 
 template <typename settings> void ProverBase<settings>::reset()

--- a/barretenberg/src/aztec/plonk/proof_system/prover/prover.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/prover/prover.cpp
@@ -58,25 +58,37 @@ template <typename settings> void ProverBase<settings>::compute_wire_coefficient
     }
 }
 
-template <typename settings> void ProverBase<settings>::compute_wire_commitments()
+template <typename settings>
+void ProverBase<settings>::receive_round_commitments(const std::vector<std::string>& tags,
+                                                     const std::vector<g1::affine_element>& commitments)
 {
-    std::array<g1::element, settings::program_width> W;
+    for (size_t i = 0; i < tags.size(); ++i) {
+        transcript.add_element(tags[i], commitments[i].to_buffer());
+    }
+}
+
+template <typename settings> void ProverBase<settings>::compute_round_commitments(const size_t round_index)
+{
+    auto multiplication_states = key->round_multiplications[round_index - 1];
+
+    for (auto mul_state : multiplication_states) {
+        barretenberg::g1::affine_element result(barretenberg::scalar_multiplication::pippenger_unsafe(
+            mul_state.scalars, mul_state.points, mul_state.num_multiplications, key->pippenger_runtime_state));
+        transcript.add_element(mul_state.tag, result.to_buffer());
+    }
+}
+
+template <typename settings> void ProverBase<settings>::compute_wire_pre_commitments()
+{
     for (size_t i = 0; i < settings::program_width; ++i) {
         std::string wire_tag = "w_" + std::to_string(i + 1);
-        W[i] = barretenberg::scalar_multiplication::pippenger_unsafe(witness->wires.at(wire_tag).get_coefficients(),
-                                                                     key->reference_string->get_monomials(),
-                                                                     n,
-                                                                     key->pippenger_runtime_state);
-    }
-
-    g1::element::batch_normalize(&W[0], settings::program_width);
-
-    for (size_t i = 0; i < settings::program_width; ++i) {
-        g1::affine_element W_affine;
-        W_affine.x = W[i].x;
-        W_affine.y = W[i].y;
-        std::string tag = "W_" + std::to_string(i + 1);
-        transcript.add_element(tag, W_affine.to_buffer());
+        prover_multiplication_state mul_state{
+            "W_" + std::to_string(i + 1),
+            witness->wires.at(wire_tag).get_coefficients(),
+            key->reference_string->get_monomials(),
+            n,
+        };
+        key->round_multiplications[0].push_back(mul_state);
     }
 
     // add public inputs
@@ -86,326 +98,20 @@ template <typename settings> void ProverBase<settings>::compute_wire_commitments
         public_wires.push_back(public_wires_source[i]);
     }
     transcript.add_element("public_inputs", fr::to_buffer(public_wires));
-
-    transcript.apply_fiat_shamir("beta");
 }
 
-template <typename settings> void ProverBase<settings>::compute_z_commitment()
-{
-    g1::element Z = barretenberg::scalar_multiplication::pippenger_unsafe(
-        key->z.get_coefficients(), key->reference_string->get_monomials(), n, key->pippenger_runtime_state);
-    g1::affine_element Z_affine;
-    Z_affine = g1::affine_element(Z);
-
-    transcript.add_element("Z", Z_affine.to_buffer());
-}
-
-template <typename settings> void ProverBase<settings>::compute_quotient_commitment()
+template <typename settings> void ProverBase<settings>::compute_quotient_pre_commitment()
 {
     std::array<g1::element, settings::program_width> T;
     for (size_t i = 0; i < settings::program_width; ++i) {
         const size_t offset = n * i;
-        T[i] = barretenberg::scalar_multiplication::pippenger_unsafe(&key->quotient_large.get_coefficients()[offset],
-                                                                     key->reference_string->get_monomials(),
-                                                                     n,
-                                                                     key->pippenger_runtime_state);
-    }
-
-    g1::element::batch_normalize(&T[0], settings::program_width);
-
-    for (size_t i = 0; i < settings::program_width; ++i) {
-        g1::affine_element T_affine;
-        T_affine.x = T[i].x;
-        T_affine.y = T[i].y;
-        std::string tag = "T_" + std::to_string(i + 1);
-        transcript.add_element(tag, T_affine.to_buffer());
-    }
-
-    transcript.apply_fiat_shamir("z"); // end of 3rd round
-}
-
-template <typename settings> void ProverBase<settings>::compute_z_coefficients()
-{
-    polynomial& z = key->z;
-
-    fr* accumulators[(settings::program_width == 1) ? 3 : settings::program_width * 2];
-    accumulators[0] = &z[1];
-    accumulators[1] = &key->z_fft[0];
-    accumulators[2] = &key->z_fft[n];
-
-    if constexpr (settings::program_width * 2 > 2) {
-        accumulators[3] = &key->z_fft[n + n];
-    }
-    if constexpr (settings::program_width > 2) {
-        accumulators[4] = &key->z_fft[n + n + n];
-        accumulators[5] = &key->opening_poly[0];
-    }
-    if constexpr (settings::program_width > 3) {
-        accumulators[6] = &key->shifted_opening_poly[0];
-        accumulators[7] = &key->quotient_large[0];
-    }
-    if constexpr (settings::program_width > 4) {
-        accumulators[8] = &key->linear_poly[0];
-        accumulators[9] = &key->quotient_large[n];
-    }
-    if constexpr (settings::program_width > 5) {
-        accumulators[10] = &key->quotient_large[n + n];
-        accumulators[11] = &key->quotient_large[n + n + n];
-    }
-    for (size_t k = 7; k < settings::program_width; ++k) {
-        // we're out of temporary memory!
-        accumulators[(k - 1) * 2] = static_cast<fr*>(aligned_alloc(64, sizeof(fr) * n));
-        accumulators[(k - 1) * 2 + 1] = static_cast<fr*>(aligned_alloc(64, sizeof(fr) * n));
-    }
-
-    fr beta = fr::serialize_from_buffer(transcript.get_challenge("beta").begin());
-    fr gamma = fr::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
-
-    std::array<fr*, settings::program_width> lagrange_base_wires;
-    std::array<fr*, settings::program_width> lagrange_base_sigmas;
-
-    for (size_t i = 0; i < settings::program_width; ++i) {
-        lagrange_base_wires[i] = &key->wire_ffts.at("w_" + std::to_string(i + 1) + "_fft")[0];
-        lagrange_base_sigmas[i] = &key->permutation_selectors_lagrange_base.at("sigma_" + std::to_string(i + 1))[0];
-    }
-
-#ifndef NO_MULTITHREADING
-#pragma omp parallel
-#endif
-    {
-#ifndef NO_MULTITHREADING
-#pragma omp for
-#endif
-        for (size_t j = 0; j < key->small_domain.num_threads; ++j) {
-            fr thread_root = key->small_domain.root.pow(static_cast<uint64_t>(j * key->small_domain.thread_size));
-            fr work_root = thread_root * beta;
-            fr T0;
-            fr wire_plus_gamma;
-            size_t start = j * key->small_domain.thread_size;
-            size_t end = (j + 1) * key->small_domain.thread_size;
-            for (size_t i = start; i < end; ++i) {
-                wire_plus_gamma = gamma + lagrange_base_wires[0][i];
-                accumulators[0][i] = wire_plus_gamma + work_root;
-
-                T0 = lagrange_base_sigmas[0][i] * beta;
-                accumulators[settings::program_width][i] = T0 + wire_plus_gamma;
-
-                for (size_t k = 1; k < settings::program_width; ++k) {
-                    wire_plus_gamma = gamma + lagrange_base_wires[k][i];
-                    T0 = fr::coset_generator(k - 1) * work_root;
-                    accumulators[k][i] = T0 + wire_plus_gamma;
-
-                    T0 = lagrange_base_sigmas[k][i] * beta;
-                    accumulators[k + settings::program_width][i] = T0 + wire_plus_gamma;
-                }
-
-                work_root *= key->small_domain.root;
-            }
-        }
-
-        // step 2: compute the constituent components of Z(X). This is a small multithreading bottleneck, as we have
-        // settings::program_width * 2 non-parallelizable processes
-#ifndef NO_MULTITHREADING
-#pragma omp for
-#endif
-        for (size_t i = 0; i < settings::program_width * 2; ++i) {
-            fr* coeffs = &accumulators[i][0];
-            for (size_t j = 0; j < key->small_domain.size - 1; ++j) {
-                coeffs[j + 1] *= coeffs[j];
-            }
-        }
-
-        // step 3: concatenate together the accumulator elements into Z(X)
-#ifndef NO_MULTITHREADING
-#pragma omp for
-#endif
-        for (size_t j = 0; j < key->small_domain.num_threads; ++j) {
-            const size_t start = j * key->small_domain.thread_size;
-            const size_t end =
-                ((j + 1) * key->small_domain.thread_size) - ((j == key->small_domain.num_threads - 1) ? 1 : 0);
-            fr inversion_accumulator = fr::one();
-            constexpr size_t inversion_index = (settings::program_width == 1) ? 2 : settings::program_width * 2 - 1;
-            fr* inversion_coefficients = &accumulators[inversion_index][0];
-            for (size_t i = start; i < end; ++i) {
-
-                for (size_t k = 1; k < settings::program_width; ++k) {
-                    accumulators[0][i] *= accumulators[k][i];
-                    accumulators[settings::program_width][i] *= accumulators[settings::program_width + k][i];
-                }
-                inversion_coefficients[i] = accumulators[0][i] * inversion_accumulator;
-                inversion_accumulator *= accumulators[settings::program_width][i];
-            }
-            inversion_accumulator = inversion_accumulator.invert();
-            for (size_t i = end - 1; i != start - 1; --i) {
-
-                // N.B. accumulators[0][i] = z[i + 1]
-                // We can avoid fully reducing z[i + 1] as the inverse fft will take care of that for us
-                accumulators[0][i] = inversion_accumulator * inversion_coefficients[i];
-                inversion_accumulator *= accumulators[settings::program_width][i];
-            }
-        }
-    }
-    z[0] = fr::one();
-    z.ifft(key->small_domain);
-    for (size_t k = 7; k < settings::program_width; ++k) {
-        aligned_free(accumulators[(k - 1) * 2]);
-        aligned_free(accumulators[(k - 1) * 2 + 1]);
-    }
-}
-
-template <typename settings> void ProverBase<settings>::compute_permutation_grand_product_coefficients()
-{
-    polynomial& z_fft = key->z_fft;
-
-    fr alpha = fr::serialize_from_buffer(transcript.get_challenge("alpha").begin());
-    fr neg_alpha = -alpha;
-    fr alpha_squared = alpha.sqr();
-    fr beta = fr::serialize_from_buffer(transcript.get_challenge("beta").begin());
-    fr gamma = fr::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
-
-    // Our permutation check boils down to two 'grand product' arguments,
-    // that we represent with a single polynomial Z(X).
-    // We want to test that Z(X) has been constructed correctly.
-    // When evaluated at elements of w \in H, the numerator of Z(w) will equal the
-    // identity permutation grand product, and the denominator will equal the copy permutation grand product.
-
-    // The identity that we need to evaluate is: Z(X.w).(permutation grand product) = Z(X).(identity grand product)
-    // i.e. The next element of Z is equal to the current element of Z, multiplied by (identity grand product) /
-    // (permutation grand product)
-
-    // This method computes `Z(X).(identity grand product).{alpha}`.
-    // The random `alpha` is there to ensure our grand product polynomial identity is linearly independent from the
-    // other polynomial identities that we are going to roll into the quotient polynomial T(X).
-
-    // Specifically, we want to compute:
-    // (w_l(X) + \beta.sigma1(X) + \gamma).(w_r(X) + \beta.sigma2(X) + \gamma).(w_o(X) + \beta.sigma3(X) +
-    // \gamma).Z(X).alpha Once we divide by the vanishing polynomial, this will be a degree 3n polynomial.
-
-    // Multiply Z(X) by \alpha^2 when performing fft transform - we get this for free if we roll \alpha^2 into the
-    // multiplicative generator
-    z_fft.coset_fft_with_constant(key->large_domain, alpha);
-
-    // We actually want Z(X.w) as well as Z(X)! But that's easy to get. z_fft contains Z(X) evaluated at the 4n'th roots
-    // of unity. So z_fft(i) = Z(w^{i/4}) i.e. z_fft(i + 4) = Z(w^{i/4}.w)
-    // => if virtual term 'foo' contains a 4n fft of Z(X.w), then z_fft(i + 4) = foo(i)
-    // So all we need to do, to get Z(X.w) is to offset indexes to z_fft by 4.
-    // If `i >= 4n  4`, we need to wrap around to the start - so just append the 4 starting elements to the end of z_fft
-    z_fft.add_lagrange_base_coefficient(z_fft[0]);
-    z_fft.add_lagrange_base_coefficient(z_fft[1]);
-    z_fft.add_lagrange_base_coefficient(z_fft[2]);
-    z_fft.add_lagrange_base_coefficient(z_fft[3]);
-
-    std::array<fr*, settings::program_width> wire_ffts;
-    std::array<fr*, settings::program_width> sigma_ffts;
-
-    for (size_t i = 0; i < settings::program_width; ++i) {
-        wire_ffts[i] = &key->wire_ffts.at("w_" + std::to_string(i + 1) + "_fft")[0];
-        sigma_ffts[i] = &key->permutation_selector_ffts.at("sigma_" + std::to_string(i + 1) + "_fft")[0];
-    }
-
-    const polynomial& l_1 = key->lagrange_1;
-
-    // compute our public input component
-    std::vector<barretenberg::fr> public_inputs =
-        barretenberg::fr::from_buffer(transcript.get_element("public_inputs"));
-
-    fr public_input_delta = compute_public_input_delta(public_inputs, beta, gamma, key->small_domain.root);
-    public_input_delta *= alpha;
-
-    polynomial& quotient_large = key->quotient_large;
-    // Step 4: Set the quotient polynomial to be equal to
-    // (w_l(X) + \beta.sigma1(X) + \gamma).(w_r(X) + \beta.sigma2(X) + \gamma).(w_o(X) + \beta.sigma3(X) +
-    // \gamma).Z(X).alpha
-#ifndef NO_MULTITHREADING
-#pragma omp parallel for
-#endif
-    for (size_t j = 0; j < key->large_domain.num_threads; ++j) {
-        const size_t start = j * key->large_domain.thread_size;
-        const size_t end = (j + 1) * key->large_domain.thread_size;
-
-        fr work_root = key->large_domain.root.pow(static_cast<uint64_t>(j * key->large_domain.thread_size));
-        work_root *= key->small_domain.generator;
-        // work_root *= fr::coset_generator(0);
-        work_root *= beta;
-
-        fr wire_plus_gamma;
-        fr T0;
-        fr denominator;
-        fr numerator;
-        for (size_t i = start; i < end; ++i) {
-            wire_plus_gamma = gamma + wire_ffts[0][i];
-
-            // Numerator computation
-            numerator = work_root + wire_plus_gamma;
-
-            // Denominator computation
-            denominator = sigma_ffts[0][i] * beta;
-            denominator += wire_plus_gamma;
-
-            for (size_t k = 1; k < settings::program_width; ++k) {
-                wire_plus_gamma = gamma + wire_ffts[k][i];
-                T0 = fr::coset_generator(k - 1) * work_root;
-                T0 += wire_plus_gamma;
-                numerator *= T0;
-
-                T0 = sigma_ffts[k][i] * beta;
-                T0 += wire_plus_gamma;
-                denominator *= T0;
-            }
-
-            numerator *= z_fft[i];
-            denominator *= z_fft[i + 4];
-
-            /**
-             * Permutation bounds check
-             * (Z(X.w) - 1).(\alpha^3).L{n-1}(X) = T(X)Z_H(X)
-             **/
-            // The \alpha^3 term is so that we can subsume this polynomial into the quotient polynomial,
-            // whilst ensuring the term is linearly independent form the other terms in the quotient polynomial
-
-            // We want to verify that Z(X) equals `1` when evaluated at `w_n`, the 'last' element of our multiplicative
-            // subgroup H. But PLONK's 'vanishing polynomial', Z*_H(X), isn't the true vanishing polynomial of subgroup
-            // H. We need to cut a root of unity out of Z*_H(X), specifically `w_n`, for our grand product argument.
-            // When evaluating Z(X) has been constructed correctly, we verify that Z(X.w).(identity permutation product)
-            // = Z(X).(sigma permutation product), for all X \in H. But this relationship breaks down for X = w_n,
-            // because Z(X.w) will evaluate to the *first* element of our grand product argument. The last element of
-            // Z(X) has a dependency on the first element, so the first element cannot have a dependency on the last
-            // element.
-
-            // TODO: With the reduction from 2 Z polynomials to a single Z(X), the above no longer applies
-            // TODO: Fix this to remove the (Z(X.w) - 1).L_{n-1}(X) check
-
-            // To summarise, we can't verify claims about Z(X) when evaluated at `w_n`.
-            // But we can verify claims about Z(X.w) when evaluated at `w_{n-1}`, which is the same thing
-
-            // To summarise the summary: If Z(w_n) = 1, then (Z(X.w) - 1).L_{n-1}(X) will be divisible by Z_H*(X)
-            // => add linearly independent term (Z(X.w) - 1).(\alpha^3).L{n-1}(X) into the quotient polynomial to check
-            // this
-
-            // z_fft already contains evaluations of Z(X).(\alpha^2)
-            // at the (2n)'th roots of unity
-            // => to get Z(X.w) instead of Z(X), index element (i+2) instead of i
-            T0 = z_fft[i + 4] - public_input_delta; // T0 = (Z(X.w) - (delta)).(\alpha^2)
-            T0 *= alpha;                            // T0 = (Z(X.w) - (delta)).(\alpha^3)
-            T0 *= l_1[i + 8];                       // T0 = (Z(X.w)-delta).(\alpha^3).L{n-1}
-            numerator += T0;
-
-            // Step 2: Compute (Z(X) - 1).(\alpha^4).L1(X)
-            // We need to verify that Z(X) equals `1` when evaluated at the first element of our subgroup H
-            // i.e. Z(X) starts at 1 and ends at 1
-            // The `alpha^4` term is so that we can add this as a linearly independent term in our quotient polynomial
-            T0 = z_fft[i] + neg_alpha; // T0 = (Z(X) - 1).(\alpha^2)
-            T0 *= alpha_squared;       // T0 = (Z(X) - 1).(\alpha^4)
-            T0 *= l_1[i];              // T0 = (Z(X) - 1).(\alpha^2).L1(X)
-            numerator += T0;
-
-            // Combine into quotient polynomial
-            T0 = numerator - denominator;
-            quotient_large[i] = T0;
-
-            // Update our working root of unity
-            work_root *= key->large_domain.root;
-        }
+        prover_multiplication_state mul_state{
+            "T_" + std::to_string(i + 1),
+            &key->quotient_large.get_coefficients()[offset],
+            key->reference_string->get_monomials(),
+            n,
+        };
+        key->round_multiplications[2].push_back(mul_state);
     }
 }
 
@@ -452,7 +158,7 @@ template <typename settings> void ProverBase<settings>::execute_first_round()
 #ifdef DEBUG_TIMING
     start = std::chrono::steady_clock::now();
 #endif
-    compute_wire_commitments();
+    compute_wire_pre_commitments();
     for (auto& widget : widgets) {
         widget->compute_round_commitments(transcript, 1);
     }
@@ -465,10 +171,10 @@ template <typename settings> void ProverBase<settings>::execute_first_round()
 
 template <typename settings> void ProverBase<settings>::execute_second_round()
 {
+    transcript.apply_fiat_shamir("beta");
 #ifdef DEBUG_TIMING
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 #endif
-    // compute_z_coefficients();
 #ifdef DEBUG_TIMING
     std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
     std::chrono::milliseconds diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -480,8 +186,6 @@ template <typename settings> void ProverBase<settings>::execute_second_round()
     for (auto& widget : widgets) {
         widget->compute_round_commitments(transcript, 2);
     }
-    // compute_z_commitment();
-    transcript.apply_fiat_shamir("alpha");
 #ifdef DEBUG_TIMING
     end = std::chrono::steady_clock::now();
     diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -491,6 +195,7 @@ template <typename settings> void ProverBase<settings>::execute_second_round()
 
 template <typename settings> void ProverBase<settings>::execute_third_round()
 {
+    transcript.apply_fiat_shamir("alpha");
 #ifdef DEBUG_TIMING
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 #endif
@@ -525,7 +230,6 @@ template <typename settings> void ProverBase<settings>::execute_third_round()
 #ifdef DEBUG_TIMING
     start = std::chrono::steady_clock::now();
 #endif
-    // compute_permutation_grand_product_coefficients();
 #ifdef DEBUG_TIMING
     end = std::chrono::steady_clock::now();
     diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -583,7 +287,7 @@ template <typename settings> void ProverBase<settings>::execute_third_round()
 #ifdef DEBUG_TIMING
     start = std::chrono::steady_clock::now();
 #endif
-    compute_quotient_commitment();
+    compute_quotient_pre_commitment();
 #ifdef DEBUG_TIMING
     end = std::chrono::steady_clock::now();
     diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -593,6 +297,7 @@ template <typename settings> void ProverBase<settings>::execute_third_round()
 
 template <typename settings> void ProverBase<settings>::execute_fourth_round()
 {
+    transcript.apply_fiat_shamir("z"); // end of 3rd round
 #ifdef DEBUG_TIMING
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 #endif
@@ -602,11 +307,11 @@ template <typename settings> void ProverBase<settings>::execute_fourth_round()
     std::chrono::milliseconds diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     std::cout << "compute linearisation coefficients: " << diff.count() << "ms" << std::endl;
 #endif
-    transcript.apply_fiat_shamir("nu");
 }
 
 template <typename settings> void ProverBase<settings>::execute_fifth_round()
 {
+    transcript.apply_fiat_shamir("nu");
 #ifdef DEBUG_TIMING
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 #endif
@@ -739,27 +444,26 @@ template <typename settings> void ProverBase<settings>::execute_fifth_round()
 #ifdef DEBUG_TIMING
     start = std::chrono::steady_clock::now();
 #endif
-    g1::element PI_Z = barretenberg::scalar_multiplication::pippenger_unsafe(
-        opening_poly.get_coefficients(), key->reference_string->get_monomials(), n, key->pippenger_runtime_state);
 
-    g1::element PI_Z_OMEGA =
-        barretenberg::scalar_multiplication::pippenger_unsafe(shifted_opening_poly.get_coefficients(),
-                                                              key->reference_string->get_monomials(),
-                                                              n,
-                                                              key->pippenger_runtime_state);
-
-    g1::affine_element PI_Z_affine;
-    g1::affine_element PI_Z_OMEGA_affine;
-
-    PI_Z_affine = g1::affine_element(PI_Z);
-    PI_Z_OMEGA_affine = g1::affine_element(PI_Z_OMEGA);
+    prover_multiplication_state pi_z{
+        "PI_Z",
+        opening_poly.get_coefficients(),
+        key->reference_string->get_monomials(),
+        n,
+    };
+    key->round_multiplications[4].push_back(pi_z);
+    prover_multiplication_state pi_z_omega{
+        "PI_Z_OMEGA",
+        shifted_opening_poly.get_coefficients(),
+        key->reference_string->get_monomials(),
+        n,
+    };
+    key->round_multiplications[4].push_back(pi_z_omega);
 #ifdef DEBUG_TIMING
     end = std::chrono::steady_clock::now();
     diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     std::cout << "compute opening commitment: " << diff.count() << "ms" << std::endl;
 #endif
-    transcript.add_element("PI_Z", PI_Z_affine.to_buffer());
-    transcript.add_element("PI_Z_OMEGA", PI_Z_OMEGA_affine.to_buffer());
 }
 
 template <typename settings> barretenberg::fr ProverBase<settings>::compute_linearisation_coefficients()
@@ -769,7 +473,6 @@ template <typename settings> barretenberg::fr ProverBase<settings>::compute_line
     fr shifted_z = z_challenge * key->small_domain.root;
 
     polynomial& r = key->linear_poly;
-    // polynomial& z = key->z;
     // ok... now we need to evaluate polynomials. Jeepers
 
     // evaluate the prover and instance polynomials.
@@ -812,10 +515,14 @@ template <typename settings> waffle::plonk_proof ProverBase<settings>::construct
 {
     execute_preamble_round();
     execute_first_round();
+    compute_round_commitments(1);
     execute_second_round();
+    compute_round_commitments(2);
     execute_third_round();
+    compute_round_commitments(3);
     execute_fourth_round();
     execute_fifth_round();
+    compute_round_commitments(5);
 
     waffle::plonk_proof result;
     result.proof_data = transcript.export_transcript();

--- a/barretenberg/src/aztec/plonk/proof_system/prover/prover.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/prover/prover.cpp
@@ -98,7 +98,6 @@ template <typename settings> void ProverBase<settings>::compute_z_commitment()
     Z_affine = g1::affine_element(Z);
 
     transcript.add_element("Z", Z_affine.to_buffer());
-    transcript.apply_fiat_shamir("alpha");
 }
 
 template <typename settings> void ProverBase<settings>::compute_quotient_commitment()
@@ -469,7 +468,7 @@ template <typename settings> void ProverBase<settings>::execute_second_round()
 #ifdef DEBUG_TIMING
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 #endif
-    compute_z_coefficients();
+    // compute_z_coefficients();
 #ifdef DEBUG_TIMING
     std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
     std::chrono::milliseconds diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -481,7 +480,8 @@ template <typename settings> void ProverBase<settings>::execute_second_round()
     for (auto& widget : widgets) {
         widget->compute_round_commitments(transcript, 2);
     }
-    compute_z_commitment();
+    // compute_z_commitment();
+    transcript.apply_fiat_shamir("alpha");
 #ifdef DEBUG_TIMING
     end = std::chrono::steady_clock::now();
     diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -525,14 +525,14 @@ template <typename settings> void ProverBase<settings>::execute_third_round()
 #ifdef DEBUG_TIMING
     start = std::chrono::steady_clock::now();
 #endif
-    compute_permutation_grand_product_coefficients();
+    // compute_permutation_grand_product_coefficients();
 #ifdef DEBUG_TIMING
     end = std::chrono::steady_clock::now();
     diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     std::cout << "compute permutation grand product coeffs: " << diff.count() << "ms" << std::endl;
 #endif
-    fr alpha = fr::serialize_from_buffer(transcript.get_challenge("alpha").begin());
-    fr alpha_base = alpha.sqr().sqr();
+    fr alpha_base = fr::serialize_from_buffer(transcript.get_challenge("alpha").begin());
+    // fr alpha_base = alpha.sqr().sqr();
 
     for (size_t i = 0; i < widgets.size(); ++i) {
 #ifdef DEBUG_TIMING

--- a/barretenberg/src/aztec/plonk/proof_system/prover/prover.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/prover/prover.cpp
@@ -454,6 +454,9 @@ template <typename settings> void ProverBase<settings>::execute_first_round()
     start = std::chrono::steady_clock::now();
 #endif
     compute_wire_commitments();
+    for (auto& widget : widgets) {
+        widget->compute_round_commitments(transcript, 1);
+    }
 #ifdef DEBUG_TIMING
     end = std::chrono::steady_clock::now();
     diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -475,6 +478,9 @@ template <typename settings> void ProverBase<settings>::execute_second_round()
 #ifdef DEBUG_TIMING
     start = std::chrono::steady_clock::now();
 #endif
+    for (auto& widget : widgets) {
+        widget->compute_round_commitments(transcript, 2);
+    }
     compute_z_commitment();
 #ifdef DEBUG_TIMING
     end = std::chrono::steady_clock::now();

--- a/barretenberg/src/aztec/plonk/proof_system/prover/prover.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/prover/prover.hpp
@@ -19,6 +19,10 @@ template <typename settings> class ProverBase {
     ProverBase& operator=(const ProverBase& other) = delete;
     ProverBase& operator=(ProverBase&& other);
 
+    void compute_round_commitments(const size_t round_index);
+    void receive_round_commitments(const std::vector<std::string>& tags,
+                                   const std::vector<barretenberg::g1::affine_element>& commitments);
+
     void execute_preamble_round();
     void execute_first_round();
     void execute_second_round();
@@ -26,14 +30,9 @@ template <typename settings> class ProverBase {
     void execute_fourth_round();
     void execute_fifth_round();
 
-    void compute_permutation_lagrange_base_full();
     void compute_wire_coefficients();
-    void compute_z_coefficients();
-    void compute_wire_commitments();
-    void compute_z_commitment();
-    void compute_quotient_commitment();
-    void compute_permutation_grand_product_coefficients();
-    void compute_arithmetisation_coefficients();
+    void compute_wire_pre_commitments();
+    void compute_quotient_pre_commitment();
     void init_quotient_polynomials();
     void compute_opening_elements();
 
@@ -47,8 +46,6 @@ template <typename settings> class ProverBase {
     std::vector<uint32_t> sigma_2_mapping;
     std::vector<uint32_t> sigma_3_mapping;
 
-    // Hmm, mixing runtime polymorphism and zero-knowledge proof generation. This seems fine...
-    // TODO: note from future self: totally not fine. Replace with template parameters
     std::vector<std::unique_ptr<ProverBaseWidget>> widgets;
     transcript::StandardTranscript transcript;
 

--- a/barretenberg/src/aztec/plonk/proof_system/prover/prover.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/prover/prover.hpp
@@ -20,7 +20,6 @@ template <typename settings> class ProverBase {
     ProverBase& operator=(const ProverBase& other) = delete;
     ProverBase& operator=(ProverBase&& other);
 
-
     void execute_preamble_round();
     void execute_first_round();
     void execute_second_round();
@@ -34,7 +33,23 @@ template <typename settings> class ProverBase {
     void compute_opening_elements();
 
     barretenberg::fr compute_linearisation_coefficients();
+    waffle::plonk_proof export_proof();
     waffle::plonk_proof construct_proof();
+
+    size_t get_circuit_size() const { return n; }
+
+    size_t get_num_queued_scalar_multiplications() const { return queue.get_num_queued_scalar_multiplications(); }
+
+    barretenberg::fr* get_scalar_multiplication_data(const size_t work_item_number) const
+    {
+        return queue.get_scalar_multiplication_data(work_item_number);
+    }
+
+    void put_scalar_multiplication_data(const barretenberg::g1::affine_element result, const size_t work_item_number)
+    {
+        queue.put_scalar_multiplication_data(result, work_item_number);
+    }
+
     void reset();
 
     size_t n;

--- a/barretenberg/src/aztec/plonk/proof_system/prover/prover.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/prover/prover.hpp
@@ -5,6 +5,7 @@
 #include "../types/program_settings.hpp"
 #include "../types/program_witness.hpp"
 #include "../widgets/base_widget.hpp"
+#include "./work_queue.hpp"
 
 namespace waffle {
 
@@ -19,9 +20,6 @@ template <typename settings> class ProverBase {
     ProverBase& operator=(const ProverBase& other) = delete;
     ProverBase& operator=(ProverBase&& other);
 
-    void compute_round_commitments(const size_t round_index);
-    void receive_round_commitments(const std::vector<std::string>& tags,
-                                   const std::vector<barretenberg::g1::affine_element>& commitments);
 
     void execute_preamble_round();
     void execute_first_round();
@@ -30,7 +28,6 @@ template <typename settings> class ProverBase {
     void execute_fourth_round();
     void execute_fifth_round();
 
-    void compute_wire_coefficients();
     void compute_wire_pre_commitments();
     void compute_quotient_pre_commitment();
     void init_quotient_polynomials();
@@ -52,6 +49,7 @@ template <typename settings> class ProverBase {
     std::shared_ptr<proving_key> key;
     std::shared_ptr<program_witness> witness;
 
+    work_queue queue;
     bool uses_quotient_mid;
 };
 extern template class ProverBase<unrolled_standard_settings>;

--- a/barretenberg/src/aztec/plonk/proof_system/prover/work_queue.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/prover/work_queue.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "../../transcript/transcript_wrappers.hpp"
+#include "../proving_key/proving_key.hpp"
+#include "../types/program_witness.hpp"
+
+#include <polynomials/iterate_over_domain.hpp>
+#include <polynomials/polynomial_arithmetic.hpp>
+#include <ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp>
+
+namespace waffle {
+class work_queue {
+  public:
+    enum WorkType { FFT, IFFT, PAIRED_IFFT_FFT, SCALAR_MULTIPLICATION };
+
+    struct work_item {
+        WorkType work_type;
+        barretenberg::fr* mul_scalars;
+        std::string tag;
+    };
+
+    work_queue(proving_key* prover_key = nullptr,
+               program_witness* program_witness = nullptr,
+               transcript::StandardTranscript* prover_transcript = nullptr)
+        : key(prover_key)
+        , witness(program_witness)
+        , transcript(prover_transcript)
+        , work_item_queue()
+    {}
+
+    work_queue(const work_queue& other) = default;
+    work_queue(work_queue&& other) = default;
+    work_queue& operator=(const work_queue& other) = default;
+    work_queue& operator=(work_queue&& other) = default;
+
+    void flush_queue() { work_item_queue = std::vector<work_item>(); }
+
+    void add_to_queue(const work_item& item) { work_item_queue.push_back(item); }
+
+    void process_queue()
+    {
+        for (const auto& item : work_item_queue) {
+            switch (item.work_type) {
+            // most expensive op
+            case WorkType::SCALAR_MULTIPLICATION: {
+                barretenberg::g1::affine_element result(
+                    barretenberg::scalar_multiplication::pippenger_unsafe(item.mul_scalars,
+                                                                          key->reference_string->get_monomials(),
+                                                                          key->small_domain.size,
+                                                                          key->pippenger_runtime_state));
+
+                transcript->add_element(item.tag, result.to_buffer());
+                break;
+            }
+            // similar in cost to fft
+            case WorkType::PAIRED_IFFT_FFT: {
+                barretenberg::polynomial& wire_fft = key->wire_ffts.at(item.tag + "_fft");
+                barretenberg::polynomial& wire = witness->wires.at(item.tag);
+                wire.ifft(key->small_domain);
+                barretenberg::polynomial_arithmetic::copy_polynomial(&wire[0], &wire_fft[0], key->n, 4 * key->n + 4);
+                wire_fft.coset_fft(key->large_domain);
+                wire_fft.add_lagrange_base_coefficient(wire_fft[0]);
+                wire_fft.add_lagrange_base_coefficient(wire_fft[1]);
+                wire_fft.add_lagrange_base_coefficient(wire_fft[2]);
+                wire_fft.add_lagrange_base_coefficient(wire_fft[3]);
+                break;
+            }
+            case WorkType::FFT: {
+                barretenberg::polynomial& wire = witness->wires.at(item.tag);
+                barretenberg::polynomial& wire_fft = key->wire_ffts.at(item.tag + "_fft");
+                barretenberg::polynomial_arithmetic::copy_polynomial(&wire[0], &wire_fft[0], key->n, 4 * key->n + 4);
+                wire_fft.coset_fft(key->large_domain);
+                wire_fft.add_lagrange_base_coefficient(wire_fft[0]);
+                wire_fft.add_lagrange_base_coefficient(wire_fft[1]);
+                wire_fft.add_lagrange_base_coefficient(wire_fft[2]);
+                wire_fft.add_lagrange_base_coefficient(wire_fft[3]);
+                break;
+            }
+            // 1/4 the cost of an fft (each fft has 1/4 the number of elements)
+            case WorkType::IFFT: {
+                barretenberg::polynomial& wire = witness->wires.at(item.tag);
+                wire.ifft(key->small_domain);
+                break;
+            }
+            default: {
+            }
+            }
+        }
+    }
+
+    std::vector<work_item> get_queue() const { return work_item_queue; }
+
+  private:
+    proving_key* key;
+    program_witness* witness;
+    transcript::StandardTranscript* transcript;
+    std::vector<work_item> work_item_queue;
+};
+} // namespace waffle

--- a/barretenberg/src/aztec/plonk/proof_system/proving_key/proving_key.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/proving_key/proving_key.cpp
@@ -23,20 +23,20 @@ proving_key::proving_key(const size_t num_gates,
     barretenberg::polynomial w_2_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
     barretenberg::polynomial w_3_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
     barretenberg::polynomial w_4_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
-    z = barretenberg::polynomial(n, n + 1);
-    z_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
+    barretenberg::polynomial z_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
 
     memset((void*)&w_1_fft[0], 0x00, sizeof(barretenberg::fr) * (4 * n + 4));
     memset((void*)&w_2_fft[0], 0x00, sizeof(barretenberg::fr) * (4 * n + 4));
     memset((void*)&w_3_fft[0], 0x00, sizeof(barretenberg::fr) * (4 * n + 4));
     memset((void*)&w_4_fft[0], 0x00, sizeof(barretenberg::fr) * (4 * n + 4));
-    memset((void*)&z[0], 0x00, sizeof(barretenberg::fr) * n);
     memset((void*)&z_fft[0], 0x00, sizeof(barretenberg::fr) * (4 * n + 4));
+    // memset((void*)&z[0], 0x00, sizeof(barretenberg::fr) * n);
 
     wire_ffts.insert({ "w_1_fft", std::move(w_1_fft) });
     wire_ffts.insert({ "w_2_fft", std::move(w_2_fft) });
     wire_ffts.insert({ "w_3_fft", std::move(w_3_fft) });
     wire_ffts.insert({ "w_4_fft", std::move(w_4_fft) });
+    wire_ffts.insert({ "z_fft", std::move(z_fft) });
 
     lagrange_1 = barretenberg::polynomial(4 * n, 4 * n + 8);
     barretenberg::polynomial_arithmetic::compute_lagrange_polynomial_fft(
@@ -63,9 +63,6 @@ proving_key::proving_key(const size_t num_gates,
     memset((void*)&quotient_mid[0], 0x00, sizeof(barretenberg::fr) * 2 * n);
     memset((void*)&quotient_large[0], 0x00, sizeof(barretenberg::fr) * 4 * n);
 
-    for (size_t i = 0; i < 5; ++i) {
-        round_multiplications.push_back(std::vector<prover_multiplication_state>());
-    }
     // size_t memory = opening_poly.get_max_size() * 32;
     // memory += (linear_poly.get_max_size() * 32);
     // memory += (shifted_opening_poly.get_max_size() * 32);
@@ -94,7 +91,7 @@ void proving_key::reset()
     barretenberg::polynomial w_2_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
     barretenberg::polynomial w_3_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
     barretenberg::polynomial w_4_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
-    z_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
+    barretenberg::polynomial z_fft = barretenberg::polynomial(4 * n + 4, 4 * n + 4);
 
     memset((void*)&w_1_fft[0], 0x00, sizeof(barretenberg::fr) * (4 * n + 4));
     memset((void*)&w_2_fft[0], 0x00, sizeof(barretenberg::fr) * (4 * n + 4));
@@ -106,6 +103,7 @@ void proving_key::reset()
     wire_ffts.insert({ "w_2_fft", std::move(w_2_fft) });
     wire_ffts.insert({ "w_3_fft", std::move(w_3_fft) });
     wire_ffts.insert({ "w_4_fft", std::move(w_4_fft) });
+    wire_ffts.insert({ "z_fft", std::move(z_fft) });
 }
 
 proving_key::proving_key(const proving_key& other)
@@ -121,14 +119,11 @@ proving_key::proving_key(const proving_key& other)
     , mid_domain(other.mid_domain)
     , large_domain(other.large_domain)
     , reference_string(other.reference_string)
-    , z(other.z)
-    , z_fft(other.z_fft)
     , lagrange_1(other.lagrange_1)
     , opening_poly(other.opening_poly)
     , shifted_opening_poly(other.shifted_opening_poly)
     , linear_poly(other.linear_poly)
     , pippenger_runtime_state(n)
-    , round_multiplications(other.round_multiplications.begin(), other.round_multiplications.end())
 {}
 
 proving_key::proving_key(proving_key&& other)
@@ -144,14 +139,11 @@ proving_key::proving_key(proving_key&& other)
     , mid_domain(std::move(other.mid_domain))
     , large_domain(std::move(other.large_domain))
     , reference_string(std::move(other.reference_string))
-    , z(std::move(other.z))
-    , z_fft(std::move(other.z_fft))
     , lagrange_1(std::move(other.lagrange_1))
     , opening_poly(std::move(other.opening_poly))
     , shifted_opening_poly(std::move(other.shifted_opening_poly))
     , linear_poly(std::move(other.linear_poly))
     , pippenger_runtime_state(std::move(other.pippenger_runtime_state))
-    , round_multiplications(std::move(other.round_multiplications))
 
 {}
 
@@ -169,14 +161,11 @@ proving_key& proving_key::operator=(proving_key&& other)
     mid_domain = std::move(other.mid_domain);
     large_domain = std::move(other.large_domain);
     reference_string = std::move(other.reference_string);
-    z = std::move(other.z);
-    z_fft = std::move(other.z_fft);
     lagrange_1 = std::move(other.lagrange_1);
     opening_poly = std::move(other.opening_poly);
     shifted_opening_poly = std::move(other.shifted_opening_poly);
     linear_poly = std::move(other.linear_poly);
     pippenger_runtime_state = std::move(other.pippenger_runtime_state);
-    round_multiplications = std::move(other.round_multiplications);
     return *this;
 }
 } // namespace waffle

--- a/barretenberg/src/aztec/plonk/proof_system/proving_key/proving_key.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/proving_key/proving_key.cpp
@@ -63,6 +63,9 @@ proving_key::proving_key(const size_t num_gates,
     memset((void*)&quotient_mid[0], 0x00, sizeof(barretenberg::fr) * 2 * n);
     memset((void*)&quotient_large[0], 0x00, sizeof(barretenberg::fr) * 4 * n);
 
+    for (size_t i = 0; i < 5; ++i) {
+        round_multiplications.push_back(std::vector<prover_multiplication_state>());
+    }
     // size_t memory = opening_poly.get_max_size() * 32;
     // memory += (linear_poly.get_max_size() * 32);
     // memory += (shifted_opening_poly.get_max_size() * 32);
@@ -125,6 +128,7 @@ proving_key::proving_key(const proving_key& other)
     , shifted_opening_poly(other.shifted_opening_poly)
     , linear_poly(other.linear_poly)
     , pippenger_runtime_state(n)
+    , round_multiplications(other.round_multiplications.begin(), other.round_multiplications.end())
 {}
 
 proving_key::proving_key(proving_key&& other)
@@ -147,6 +151,8 @@ proving_key::proving_key(proving_key&& other)
     , shifted_opening_poly(std::move(other.shifted_opening_poly))
     , linear_poly(std::move(other.linear_poly))
     , pippenger_runtime_state(std::move(other.pippenger_runtime_state))
+    , round_multiplications(std::move(other.round_multiplications))
+
 {}
 
 proving_key& proving_key::operator=(proving_key&& other)
@@ -170,6 +176,7 @@ proving_key& proving_key::operator=(proving_key&& other)
     shifted_opening_poly = std::move(other.shifted_opening_poly);
     linear_poly = std::move(other.linear_poly);
     pippenger_runtime_state = std::move(other.pippenger_runtime_state);
+    round_multiplications = std::move(other.round_multiplications);
     return *this;
 }
 } // namespace waffle

--- a/barretenberg/src/aztec/plonk/proof_system/proving_key/proving_key.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/proving_key/proving_key.hpp
@@ -6,6 +6,13 @@
 #include <polynomials/polynomial.hpp>
 
 namespace waffle {
+struct prover_multiplication_state {
+    std::string tag;
+    barretenberg::fr* scalars;
+    barretenberg::g1::affine_element* points;
+    const size_t num_multiplications;
+};
+
 struct proving_key {
   public:
     proving_key(const size_t num_gates, const size_t num_inputs, std::shared_ptr<ProverReferenceString> const& crs);
@@ -51,6 +58,8 @@ struct proving_key {
     barretenberg::polynomial quotient_large;
 
     barretenberg::scalar_multiplication::unsafe_pippenger_runtime_state pippenger_runtime_state;
+    std::vector<std::vector<prover_multiplication_state>> round_multiplications;
+
     static constexpr size_t min_thread_block = 4UL;
 };
 } // namespace waffle

--- a/barretenberg/src/aztec/plonk/proof_system/proving_key/proving_key.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/proving_key/proving_key.hpp
@@ -6,12 +6,6 @@
 #include <polynomials/polynomial.hpp>
 
 namespace waffle {
-struct prover_multiplication_state {
-    std::string tag;
-    barretenberg::fr* scalars;
-    barretenberg::g1::affine_element* points;
-    const size_t num_multiplications;
-};
 
 struct proving_key {
   public:
@@ -47,8 +41,6 @@ struct proving_key {
 
     std::shared_ptr<ProverReferenceString> reference_string;
 
-    barretenberg::polynomial z;
-    barretenberg::polynomial z_fft;
     barretenberg::polynomial lagrange_1;
     barretenberg::polynomial opening_poly;
     barretenberg::polynomial shifted_opening_poly;
@@ -58,7 +50,6 @@ struct proving_key {
     barretenberg::polynomial quotient_large;
 
     barretenberg::scalar_multiplication::unsafe_pippenger_runtime_state pippenger_runtime_state;
-    std::vector<std::vector<prover_multiplication_state>> round_multiplications;
 
     static constexpr size_t min_thread_block = 4UL;
 };

--- a/barretenberg/src/aztec/plonk/proof_system/types/program_settings.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/types/program_settings.hpp
@@ -81,10 +81,16 @@ class standard_verifier_settings : public standard_settings {
         std::vector<barretenberg::g1::affine_element>& points,
         std::vector<barretenberg::fr>& scalars)
     {
+        auto updated_challenge = VerifierPermutationWidget<barretenberg::fr,
+                                                           barretenberg::g1::affine_element,
+                                                           transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
+
+        updated_challenge.nu_index += 1;
         return VerifierArithmeticWidget<barretenberg::fr,
                                         barretenberg::g1::affine_element,
                                         transcript::StandardTranscript>::
-            append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
+            append_scalar_multiplication_inputs(key, updated_challenge, transcript, points, scalars, use_linearisation);
     }
 
     static size_t compute_batch_evaluation_contribution(verification_key* key,
@@ -132,10 +138,17 @@ class unrolled_standard_verifier_settings : public standard_settings {
         std::vector<barretenberg::g1::affine_element>& points,
         std::vector<barretenberg::fr>& scalars)
     {
+        auto updated_challenge = VerifierPermutationWidget<barretenberg::fr,
+                                                           barretenberg::g1::affine_element,
+                                                           transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
+
+        updated_challenge.nu_index += 1;
+
         return VerifierArithmeticWidget<barretenberg::fr,
                                         barretenberg::g1::affine_element,
                                         transcript::StandardTranscript>::
-            append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
+            append_scalar_multiplication_inputs(key, updated_challenge, transcript, points, scalars, use_linearisation);
     }
 
     static size_t compute_batch_evaluation_contribution(verification_key* key,
@@ -184,15 +197,22 @@ class mimc_verifier_settings : public standard_settings {
         std::vector<barretenberg::fr>& scalars)
     {
 
-        VerifierBaseWidget::challenge_coefficients<barretenberg::fr> result =
-            VerifierArithmeticWidget<barretenberg::fr,
-                                     barretenberg::g1::affine_element,
-                                     transcript::StandardTranscript>::
-                append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
-        result =
+        auto updated_challenge = VerifierPermutationWidget<barretenberg::fr,
+                                                           barretenberg::g1::affine_element,
+                                                           transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
+
+        updated_challenge.nu_index += 1;
+
+        updated_challenge = VerifierArithmeticWidget<barretenberg::fr,
+                                                     barretenberg::g1::affine_element,
+                                                     transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, updated_challenge, transcript, points, scalars, use_linearisation);
+        updated_challenge =
             VerifierMiMCWidget<barretenberg::fr, barretenberg::g1::affine_element, transcript::StandardTranscript>::
-                append_scalar_multiplication_inputs(key, result, transcript, points, scalars, use_linearisation);
-        return result;
+                append_scalar_multiplication_inputs(
+                    key, updated_challenge, transcript, points, scalars, use_linearisation);
+        return updated_challenge;
     }
 
     static size_t compute_batch_evaluation_contribution(verification_key* key,
@@ -249,20 +269,25 @@ class turbo_verifier_settings : public turbo_settings {
         std::vector<barretenberg::g1::affine_element>& points,
         std::vector<barretenberg::fr>& scalars)
     {
-        VerifierBaseWidget::challenge_coefficients<barretenberg::fr> result =
-            VerifierTurboFixedBaseWidget<barretenberg::fr,
-                                         barretenberg::g1::affine_element,
-                                         transcript::StandardTranscript>::
-                append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
-        result = VerifierTurboRangeWidget<barretenberg::fr,
-                                          barretenberg::g1::affine_element,
-                                          transcript::StandardTranscript>::
-            append_scalar_multiplication_inputs(key, result, transcript, points, scalars, use_linearisation);
-        result = VerifierTurboLogicWidget<barretenberg::fr,
-                                          barretenberg::g1::affine_element,
-                                          transcript::StandardTranscript>::
-            append_scalar_multiplication_inputs(key, result, transcript, points, scalars, use_linearisation);
-        return result;
+        auto updated_challenge = VerifierPermutationWidget<barretenberg::fr,
+                                                           barretenberg::g1::affine_element,
+                                                           transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
+
+        updated_challenge.nu_index += 4;
+        updated_challenge = VerifierTurboFixedBaseWidget<barretenberg::fr,
+                                                         barretenberg::g1::affine_element,
+                                                         transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, updated_challenge, transcript, points, scalars, use_linearisation);
+        updated_challenge = VerifierTurboRangeWidget<barretenberg::fr,
+                                                     barretenberg::g1::affine_element,
+                                                     transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, updated_challenge, transcript, points, scalars, use_linearisation);
+        updated_challenge = VerifierTurboLogicWidget<barretenberg::fr,
+                                                     barretenberg::g1::affine_element,
+                                                     transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, updated_challenge, transcript, points, scalars, use_linearisation);
+        return updated_challenge;
     }
 
     static size_t compute_batch_evaluation_contribution(verification_key* key,
@@ -329,22 +354,28 @@ class unrolled_turbo_verifier_settings : public unrolled_turbo_settings {
         std::vector<barretenberg::g1::affine_element>& points,
         std::vector<barretenberg::fr>& scalars)
     {
-        VerifierBaseWidget::challenge_coefficients<barretenberg::fr> result =
-            VerifierTurboFixedBaseWidget<barretenberg::fr,
-                                         barretenberg::g1::affine_element,
-                                         transcript::StandardTranscript>::
-                append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
+        auto updated_challenge = VerifierPermutationWidget<barretenberg::fr,
+                                                           barretenberg::g1::affine_element,
+                                                           transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, challenge, transcript, points, scalars, use_linearisation);
 
-        result = VerifierTurboRangeWidget<barretenberg::fr,
-                                          barretenberg::g1::affine_element,
-                                          transcript::StandardTranscript>::
-            append_scalar_multiplication_inputs(key, result, transcript, points, scalars, use_linearisation);
+        updated_challenge.nu_index += 4;
 
-        result = VerifierTurboLogicWidget<barretenberg::fr,
-                                          barretenberg::g1::affine_element,
-                                          transcript::StandardTranscript>::
-            append_scalar_multiplication_inputs(key, result, transcript, points, scalars, use_linearisation);
-        return result;
+        updated_challenge = VerifierTurboFixedBaseWidget<barretenberg::fr,
+                                                         barretenberg::g1::affine_element,
+                                                         transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, updated_challenge, transcript, points, scalars, use_linearisation);
+
+        updated_challenge = VerifierTurboRangeWidget<barretenberg::fr,
+                                                     barretenberg::g1::affine_element,
+                                                     transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, updated_challenge, transcript, points, scalars, use_linearisation);
+
+        updated_challenge = VerifierTurboLogicWidget<barretenberg::fr,
+                                                     barretenberg::g1::affine_element,
+                                                     transcript::StandardTranscript>::
+            append_scalar_multiplication_inputs(key, updated_challenge, transcript, points, scalars, use_linearisation);
+        return updated_challenge;
     }
 
     static size_t compute_batch_evaluation_contribution(verification_key* key,

--- a/barretenberg/src/aztec/plonk/proof_system/types/program_settings.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/types/program_settings.hpp
@@ -92,10 +92,15 @@ class standard_verifier_settings : public standard_settings {
                                                         const size_t nu_index,
                                                         const transcript::StandardTranscript& transcript)
     {
+        auto updated_nu_index = VerifierPermutationWidget<barretenberg::fr,
+                                                          barretenberg::g1::affine_element,
+                                                          transcript::StandardTranscript>::
+            compute_batch_evaluation_contribution(key, batch_eval, nu_index, transcript, use_linearisation);
+        ++updated_nu_index;
         return VerifierArithmeticWidget<barretenberg::fr,
                                         barretenberg::g1::affine_element,
                                         transcript::StandardTranscript>::
-            compute_batch_evaluation_contribution(key, batch_eval, nu_index, transcript, use_linearisation);
+            compute_batch_evaluation_contribution(key, batch_eval, updated_nu_index, transcript, use_linearisation);
     }
 
     static barretenberg::fr compute_quotient_evaluation_contribution(verification_key* key,
@@ -138,10 +143,15 @@ class unrolled_standard_verifier_settings : public standard_settings {
                                                         const size_t nu_index,
                                                         const transcript::StandardTranscript& transcript)
     {
+        auto updated_nu_index = VerifierPermutationWidget<barretenberg::fr,
+                                                          barretenberg::g1::affine_element,
+                                                          transcript::StandardTranscript>::
+            compute_batch_evaluation_contribution(key, batch_eval, nu_index, transcript, use_linearisation);
+        ++updated_nu_index;
         return VerifierArithmeticWidget<barretenberg::fr,
                                         barretenberg::g1::affine_element,
                                         transcript::StandardTranscript>::
-            compute_batch_evaluation_contribution(key, batch_eval, nu_index, transcript, use_linearisation);
+            compute_batch_evaluation_contribution(key, batch_eval, updated_nu_index, transcript, use_linearisation);
     }
 
     static barretenberg::fr compute_quotient_evaluation_contribution(verification_key* key,
@@ -190,10 +200,15 @@ class mimc_verifier_settings : public standard_settings {
                                                         const size_t nu_index,
                                                         const transcript::StandardTranscript& transcript)
     {
-        size_t updated_nu_index = VerifierArithmeticWidget<barretenberg::fr,
-                                                           barretenberg::g1::affine_element,
-                                                           transcript::StandardTranscript>::
+        auto updated_nu_index = VerifierPermutationWidget<barretenberg::fr,
+                                                          barretenberg::g1::affine_element,
+                                                          transcript::StandardTranscript>::
             compute_batch_evaluation_contribution(key, batch_eval, nu_index, transcript, use_linearisation);
+        ++updated_nu_index;
+        updated_nu_index = VerifierArithmeticWidget<barretenberg::fr,
+                                                    barretenberg::g1::affine_element,
+                                                    transcript::StandardTranscript>::
+            compute_batch_evaluation_contribution(key, batch_eval, updated_nu_index, transcript, use_linearisation);
         updated_nu_index =
             VerifierMiMCWidget<barretenberg::fr, barretenberg::g1::affine_element, transcript::StandardTranscript>::
                 compute_batch_evaluation_contribution(key, batch_eval, updated_nu_index, transcript, use_linearisation);
@@ -255,10 +270,15 @@ class turbo_verifier_settings : public turbo_settings {
                                                         const size_t nu_index,
                                                         const transcript::StandardTranscript& transcript)
     {
-        size_t updated_nu_index = VerifierTurboFixedBaseWidget<barretenberg::fr,
-                                                               barretenberg::g1::affine_element,
-                                                               transcript::StandardTranscript>::
+        auto updated_nu_index = VerifierPermutationWidget<barretenberg::fr,
+                                                          barretenberg::g1::affine_element,
+                                                          transcript::StandardTranscript>::
             compute_batch_evaluation_contribution(key, batch_eval, nu_index, transcript, use_linearisation);
+        updated_nu_index += 4;
+        updated_nu_index = VerifierTurboFixedBaseWidget<barretenberg::fr,
+                                                        barretenberg::g1::affine_element,
+                                                        transcript::StandardTranscript>::
+            compute_batch_evaluation_contribution(key, batch_eval, updated_nu_index, transcript, use_linearisation);
         updated_nu_index = VerifierTurboRangeWidget<barretenberg::fr,
                                                     barretenberg::g1::affine_element,
                                                     transcript::StandardTranscript>::
@@ -332,10 +352,15 @@ class unrolled_turbo_verifier_settings : public unrolled_turbo_settings {
                                                         const size_t nu_index,
                                                         const transcript::StandardTranscript& transcript)
     {
-        size_t updated_nu_index = VerifierTurboFixedBaseWidget<barretenberg::fr,
-                                                               barretenberg::g1::affine_element,
-                                                               transcript::StandardTranscript>::
+        auto updated_nu_index = VerifierPermutationWidget<barretenberg::fr,
+                                                          barretenberg::g1::affine_element,
+                                                          transcript::StandardTranscript>::
             compute_batch_evaluation_contribution(key, batch_eval, nu_index, transcript, use_linearisation);
+        updated_nu_index += 4;
+        updated_nu_index = VerifierTurboFixedBaseWidget<barretenberg::fr,
+                                                        barretenberg::g1::affine_element,
+                                                        transcript::StandardTranscript>::
+            compute_batch_evaluation_contribution(key, batch_eval, updated_nu_index, transcript, use_linearisation);
         updated_nu_index = VerifierTurboRangeWidget<barretenberg::fr,
                                                     barretenberg::g1::affine_element,
                                                     transcript::StandardTranscript>::

--- a/barretenberg/src/aztec/plonk/proof_system/types/program_settings.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/types/program_settings.hpp
@@ -10,6 +10,7 @@
 #include "../widgets/turbo_fixed_base_widget.hpp"
 #include "../widgets/turbo_logic_widget.hpp"
 #include "../widgets/turbo_range_widget.hpp"
+#include "../widgets/permutation_widget.hpp"
 
 namespace waffle {
 class settings_base {
@@ -102,10 +103,15 @@ class standard_verifier_settings : public standard_settings {
                                                                      const transcript::StandardTranscript& transcript,
                                                                      barretenberg::fr& t_eval)
     {
-        return VerifierArithmeticWidget<barretenberg::fr,
-                                        barretenberg::g1::affine_element,
-                                        transcript::StandardTranscript>::
+        auto updated_alpha_base = VerifierPermutationWidget<barretenberg::fr,
+                                                            barretenberg::g1::affine_element,
+                                                            transcript::StandardTranscript>::
             compute_quotient_evaluation_contribution(key, alpha_base, transcript, t_eval, use_linearisation);
+        updated_alpha_base = VerifierArithmeticWidget<barretenberg::fr,
+                                                      barretenberg::g1::affine_element,
+                                                      transcript::StandardTranscript>::
+            compute_quotient_evaluation_contribution(key, updated_alpha_base, transcript, t_eval, use_linearisation);
+        return updated_alpha_base;
     }
 };
 
@@ -143,10 +149,15 @@ class unrolled_standard_verifier_settings : public standard_settings {
                                                                      const transcript::StandardTranscript& transcript,
                                                                      barretenberg::fr& t_eval)
     {
+        auto updated_alpha_base = VerifierPermutationWidget<barretenberg::fr,
+                                                            barretenberg::g1::affine_element,
+                                                            transcript::StandardTranscript>::
+            compute_quotient_evaluation_contribution(key, alpha_base, transcript, t_eval, use_linearisation);
+
         return VerifierArithmeticWidget<barretenberg::fr,
                                         barretenberg::g1::affine_element,
                                         transcript::StandardTranscript>::
-            compute_quotient_evaluation_contribution(key, alpha_base, transcript, t_eval, use_linearisation);
+            compute_quotient_evaluation_contribution(key, updated_alpha_base, transcript, t_eval, use_linearisation);
     }
 };
 
@@ -194,10 +205,15 @@ class mimc_verifier_settings : public standard_settings {
                                                                      const transcript::StandardTranscript& transcript,
                                                                      barretenberg::fr& t_eval)
     {
-        barretenberg::fr updated_alpha_base = VerifierArithmeticWidget<barretenberg::fr,
-                                                                       barretenberg::g1::affine_element,
-                                                                       transcript::StandardTranscript>::
+        auto updated_alpha_base = VerifierPermutationWidget<barretenberg::fr,
+                                                            barretenberg::g1::affine_element,
+                                                            transcript::StandardTranscript>::
             compute_quotient_evaluation_contribution(key, alpha_base, transcript, t_eval, use_linearisation);
+
+        updated_alpha_base = VerifierArithmeticWidget<barretenberg::fr,
+                                                      barretenberg::g1::affine_element,
+                                                      transcript::StandardTranscript>::
+            compute_quotient_evaluation_contribution(key, updated_alpha_base, transcript, t_eval, use_linearisation);
         updated_alpha_base =
             VerifierMiMCWidget<barretenberg::fr, barretenberg::g1::affine_element, transcript::StandardTranscript>::
                 compute_quotient_evaluation_contribution(
@@ -260,10 +276,15 @@ class turbo_verifier_settings : public turbo_settings {
                                                                      const transcript::StandardTranscript& transcript,
                                                                      barretenberg::fr& t_eval)
     {
-        barretenberg::fr updated_alpha_base = VerifierTurboFixedBaseWidget<barretenberg::fr,
-                                                                           barretenberg::g1::affine_element,
-                                                                           transcript::StandardTranscript>::
+        auto updated_alpha_base = VerifierPermutationWidget<barretenberg::fr,
+                                                            barretenberg::g1::affine_element,
+                                                            transcript::StandardTranscript>::
             compute_quotient_evaluation_contribution(key, alpha_base, transcript, t_eval, use_linearisation);
+
+        updated_alpha_base = VerifierTurboFixedBaseWidget<barretenberg::fr,
+                                                          barretenberg::g1::affine_element,
+                                                          transcript::StandardTranscript>::
+            compute_quotient_evaluation_contribution(key, updated_alpha_base, transcript, t_eval, use_linearisation);
         updated_alpha_base = VerifierTurboRangeWidget<barretenberg::fr,
                                                       barretenberg::g1::affine_element,
                                                       transcript::StandardTranscript>::
@@ -331,10 +352,15 @@ class unrolled_turbo_verifier_settings : public unrolled_turbo_settings {
                                                                      const transcript::StandardTranscript& transcript,
                                                                      barretenberg::fr& t_eval)
     {
-        barretenberg::fr updated_alpha_base = VerifierTurboFixedBaseWidget<barretenberg::fr,
-                                                                           barretenberg::g1::affine_element,
-                                                                           transcript::StandardTranscript>::
+        auto updated_alpha_base = VerifierPermutationWidget<barretenberg::fr,
+                                                            barretenberg::g1::affine_element,
+                                                            transcript::StandardTranscript>::
             compute_quotient_evaluation_contribution(key, alpha_base, transcript, t_eval, use_linearisation);
+
+        updated_alpha_base = VerifierTurboFixedBaseWidget<barretenberg::fr,
+                                                          barretenberg::g1::affine_element,
+                                                          transcript::StandardTranscript>::
+            compute_quotient_evaluation_contribution(key, updated_alpha_base, transcript, t_eval, use_linearisation);
         updated_alpha_base = VerifierTurboRangeWidget<barretenberg::fr,
                                                       barretenberg::g1::affine_element,
                                                       transcript::StandardTranscript>::

--- a/barretenberg/src/aztec/plonk/proof_system/utils/linearizer.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/utils/linearizer.hpp
@@ -15,7 +15,7 @@ template <typename Field> struct plonk_linear_terms {
 // commitment to this linear polynomial from the original commitments - the prover can provide an evaluation of this
 // linear polynomial, instead of the evaluations of its consitutent polynomials. This shaves 6 field elements off of the
 // proof size!
-template <typename Field, typename Transcript, typename program_settings>
+template <typename Field, typename Transcript, size_t program_width>
 inline plonk_linear_terms<Field> compute_linear_terms(const Transcript& transcript, const Field& l_1)
 {
     Field alpha = transcript.get_challenge_field_element("alpha");
@@ -25,8 +25,8 @@ inline plonk_linear_terms<Field> compute_linear_terms(const Transcript& transcri
     Field z = transcript.get_challenge_field_element("z");
     Field z_beta = z * beta;
 
-    std::array<Field, program_settings::program_width> wire_evaluations;
-    for (size_t i = 0; i < program_settings::program_width; ++i) {
+    std::array<Field, program_width> wire_evaluations;
+    for (size_t i = 0; i < program_width; ++i) {
         wire_evaluations[i] = transcript.get_field_element("w_" + std::to_string(i + 1));
     }
 
@@ -36,7 +36,7 @@ inline plonk_linear_terms<Field> compute_linear_terms(const Transcript& transcri
 
     Field T0;
     Field z_contribution = Field(1);
-    for (size_t i = 0; i < program_settings::program_width; ++i) {
+    for (size_t i = 0; i < program_width; ++i) {
         Field coset_generator = (i == 0) ? Field(1) : Field::coset_generator(i - 1);
         T0 = z_beta * coset_generator;
         T0 += wire_evaluations[i];
@@ -48,7 +48,7 @@ inline plonk_linear_terms<Field> compute_linear_terms(const Transcript& transcri
     result.z_1 += T0;
 
     Field sigma_contribution = Field(1);
-    for (size_t i = 0; i < program_settings::program_width - 1; ++i) {
+    for (size_t i = 0; i < program_width - 1; ++i) {
         Field permutation_evaluation = transcript.get_field_element("sigma_" + std::to_string(i + 1));
         T0 = permutation_evaluation * beta;
         T0 += wire_evaluations[i];

--- a/barretenberg/src/aztec/plonk/proof_system/verification_key/verification_key.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/verification_key/verification_key.hpp
@@ -24,5 +24,7 @@ struct verification_key {
     std::map<std::string, barretenberg::g1::affine_element> constraint_selectors;
 
     std::map<std::string, barretenberg::g1::affine_element> permutation_selectors;
+
+    size_t program_width = 3;
 };
 } // namespace waffle

--- a/barretenberg/src/aztec/plonk/proof_system/verifier/verifier.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/verifier/verifier.cpp
@@ -34,6 +34,7 @@ VerifierBase<program_settings>& VerifierBase<program_settings>::operator=(Verifi
 
 template <typename program_settings> bool VerifierBase<program_settings>::verify_proof(const waffle::plonk_proof& proof)
 {
+    key->program_width = program_settings::program_width;
     transcript::StandardTranscript transcript = transcript::StandardTranscript(
         proof.proof_data, manifest, program_settings::hash_type, program_settings::num_challenge_bytes);
 
@@ -98,7 +99,7 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
     }
 
     // reconstruct challenges
-    fr alpha_pow[4];
+    // fr alpha_pow[4];
 
     transcript.add_element("circuit_size",
                            { static_cast<uint8_t>(key->n),
@@ -115,10 +116,10 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
     transcript.apply_fiat_shamir("alpha");
     transcript.apply_fiat_shamir("z");
 
-    fr beta = fr::serialize_from_buffer(transcript.get_challenge("beta").begin());
+    // fr beta = fr::serialize_from_buffer(transcript.get_challenge("beta").begin());
     fr alpha = fr::serialize_from_buffer(transcript.get_challenge("alpha").begin());
     fr z_challenge = fr::serialize_from_buffer(transcript.get_challenge("z").begin());
-    fr gamma = fr::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
+    // fr gamma = fr::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
 
     fr t_eval = fr::zero();
 
@@ -126,62 +127,59 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
         barretenberg::polynomial_arithmetic::get_lagrange_evaluations(z_challenge, key->domain);
 
     // compute the terms we need to derive R(X)
-    plonk_linear_terms linear_terms =
-        compute_linear_terms<barretenberg::fr, transcript::StandardTranscript, program_settings::program_width>(
-            transcript, lagrange_evals.l_1);
 
-    // reconstruct evaluation of quotient polynomial from prover messages
-    fr T0;
-    fr T1;
-    fr T2;
-    fr::__copy(alpha, alpha_pow[0]);
-    for (size_t i = 1; i < 4; ++i) {
-        alpha_pow[i] = alpha_pow[i - 1] * alpha_pow[0];
-    }
+    // // reconstruct evaluation of quotient polynomial from prover messages
+    // fr T0;
+    // fr T1;
+    // fr T2;
+    // fr::__copy(alpha, alpha_pow[0]);
+    // for (size_t i = 1; i < 4; ++i) {
+    //     alpha_pow[i] = alpha_pow[i - 1] * alpha_pow[0];
+    // }
 
-    fr sigma_contribution = fr::one();
+    // fr sigma_contribution = fr::one();
 
-    for (size_t i = 0; i < program_settings::program_width - 1; ++i) {
-        T0 = sigma_evaluations[i] * beta;
-        T1 = wire_evaluations[i] + gamma;
-        T0 += T1;
-        sigma_contribution *= T0;
-    }
+    // for (size_t i = 0; i < program_settings::program_width - 1; ++i) {
+    //     T0 = sigma_evaluations[i] * beta;
+    //     T1 = wire_evaluations[i] + gamma;
+    //     T0 += T1;
+    //     sigma_contribution *= T0;
+    // }
 
-    std::vector<barretenberg::fr> public_inputs =
-        barretenberg::fr::from_buffer(transcript.get_element("public_inputs"));
+    // std::vector<barretenberg::fr> public_inputs =
+    //     barretenberg::fr::from_buffer(transcript.get_element("public_inputs"));
 
-    fr public_input_delta = compute_public_input_delta(public_inputs, beta, gamma, key->domain.root);
-    T0 = wire_evaluations[program_settings::program_width - 1] + gamma;
-    sigma_contribution *= T0;
-    sigma_contribution *= z_1_shifted_eval;
-    sigma_contribution *= alpha_pow[0];
+    // fr public_input_delta = compute_public_input_delta(public_inputs, beta, gamma, key->domain.root);
+    // T0 = wire_evaluations[program_settings::program_width - 1] + gamma;
+    // sigma_contribution *= T0;
+    // sigma_contribution *= z_1_shifted_eval;
+    // sigma_contribution *= alpha_pow[0];
 
-    T1 = z_1_shifted_eval - public_input_delta;
-    T1 *= lagrange_evals.l_n_minus_1;
-    T1 *= alpha_pow[1];
+    // T1 = z_1_shifted_eval - public_input_delta;
+    // T1 *= lagrange_evals.l_n_minus_1;
+    // T1 *= alpha_pow[1];
 
-    T2 = lagrange_evals.l_1 * alpha_pow[2];
-    T1 -= T2;
-    T1 -= sigma_contribution;
+    // T2 = lagrange_evals.l_1 * alpha_pow[2];
+    // T1 -= T2;
+    // T1 -= sigma_contribution;
 
-    if constexpr (program_settings::use_linearisation) {
-        fr linear_eval = fr::serialize_from_buffer(&transcript.get_element("r")[0]);
-        T1 += linear_eval;
-    }
-    t_eval += T1;
+    // if constexpr (program_settings::use_linearisation) {
+    //     fr linear_eval = fr::serialize_from_buffer(&transcript.get_element("r")[0]);
+    //     T1 += linear_eval;
+    // }
+    // t_eval += T1;
 
-    fr alpha_base = alpha.sqr().sqr();
-
+    // fr alpha_base = alpha.sqr().sqr();
+    fr alpha_base = alpha;
     alpha_base = program_settings::compute_quotient_evaluation_contribution(key.get(), alpha_base, transcript, t_eval);
 
-    if constexpr (!program_settings::use_linearisation) {
-        fr z_eval = fr::serialize_from_buffer(&transcript.get_element("z")[0]);
-        t_eval += (linear_terms.z_1 * z_eval);
-        t_eval += (linear_terms.sigma_last * sigma_evaluations[program_settings::program_width - 1]);
-    }
+    // if constexpr (!program_settings::use_linearisation) {
+    //     fr z_eval = fr::serialize_from_buffer(&transcript.get_element("z")[0]);
+    //     t_eval += (linear_terms.z_1 * z_eval);
+    //     t_eval += (linear_terms.sigma_last * sigma_evaluations[program_settings::program_width - 1]);
+    // }
 
-    T0 = lagrange_evals.vanishing_poly.invert();
+    fr T0 = lagrange_evals.vanishing_poly.invert();
     t_eval *= T0;
     transcript.add_element("t", t_eval.to_buffer());
 
@@ -252,6 +250,9 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
 
     elements.emplace_back(Z_1);
     if constexpr (program_settings::use_linearisation) {
+        plonk_linear_terms linear_terms =
+            compute_linear_terms<barretenberg::fr, transcript::StandardTranscript, program_settings::program_width>(
+                transcript, lagrange_evals.l_1);
         linear_terms.z_1 *= nu_challenges[0];
         linear_terms.z_1 += (nu_challenges[nu_z_offset] * u);
         scalars.emplace_back(linear_terms.z_1);
@@ -283,6 +284,9 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
     }
 
     if constexpr (program_settings::use_linearisation) {
+        plonk_linear_terms linear_terms =
+            compute_linear_terms<barretenberg::fr, transcript::StandardTranscript, program_settings::program_width>(
+                transcript, lagrange_evals.l_1);
         elements.emplace_back(
             key->permutation_selectors.at("SIGMA_" + std::to_string(program_settings::program_width)));
         linear_terms.sigma_last *= nu_challenges[0];

--- a/barretenberg/src/aztec/plonk/proof_system/verifier/verifier.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/verifier/verifier.cpp
@@ -61,7 +61,6 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
     g1::affine_element PI_Z = g1::affine_element::serialize_from_buffer(&transcript.get_element("PI_Z")[0]);
     g1::affine_element PI_Z_OMEGA = g1::affine_element::serialize_from_buffer(&transcript.get_element("PI_Z_OMEGA")[0]);
 
-    fr z_1_shifted_eval = fr::serialize_from_buffer(&transcript.get_element("z_omega")[0]);
 
     bool inputs_valid = T[0].on_curve() && Z_1.on_curve() && PI_Z.on_curve();
 
@@ -116,68 +115,16 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
     transcript.apply_fiat_shamir("alpha");
     transcript.apply_fiat_shamir("z");
 
-    // fr beta = fr::serialize_from_buffer(transcript.get_challenge("beta").begin());
     fr alpha = fr::serialize_from_buffer(transcript.get_challenge("alpha").begin());
     fr z_challenge = fr::serialize_from_buffer(transcript.get_challenge("z").begin());
-    // fr gamma = fr::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
 
     fr t_eval = fr::zero();
 
     barretenberg::polynomial_arithmetic::lagrange_evaluations lagrange_evals =
         barretenberg::polynomial_arithmetic::get_lagrange_evaluations(z_challenge, key->domain);
 
-    // compute the terms we need to derive R(X)
-
-    // // reconstruct evaluation of quotient polynomial from prover messages
-    // fr T0;
-    // fr T1;
-    // fr T2;
-    // fr::__copy(alpha, alpha_pow[0]);
-    // for (size_t i = 1; i < 4; ++i) {
-    //     alpha_pow[i] = alpha_pow[i - 1] * alpha_pow[0];
-    // }
-
-    // fr sigma_contribution = fr::one();
-
-    // for (size_t i = 0; i < program_settings::program_width - 1; ++i) {
-    //     T0 = sigma_evaluations[i] * beta;
-    //     T1 = wire_evaluations[i] + gamma;
-    //     T0 += T1;
-    //     sigma_contribution *= T0;
-    // }
-
-    // std::vector<barretenberg::fr> public_inputs =
-    //     barretenberg::fr::from_buffer(transcript.get_element("public_inputs"));
-
-    // fr public_input_delta = compute_public_input_delta(public_inputs, beta, gamma, key->domain.root);
-    // T0 = wire_evaluations[program_settings::program_width - 1] + gamma;
-    // sigma_contribution *= T0;
-    // sigma_contribution *= z_1_shifted_eval;
-    // sigma_contribution *= alpha_pow[0];
-
-    // T1 = z_1_shifted_eval - public_input_delta;
-    // T1 *= lagrange_evals.l_n_minus_1;
-    // T1 *= alpha_pow[1];
-
-    // T2 = lagrange_evals.l_1 * alpha_pow[2];
-    // T1 -= T2;
-    // T1 -= sigma_contribution;
-
-    // if constexpr (program_settings::use_linearisation) {
-    //     fr linear_eval = fr::serialize_from_buffer(&transcript.get_element("r")[0]);
-    //     T1 += linear_eval;
-    // }
-    // t_eval += T1;
-
-    // fr alpha_base = alpha.sqr().sqr();
     fr alpha_base = alpha;
     alpha_base = program_settings::compute_quotient_evaluation_contribution(key.get(), alpha_base, transcript, t_eval);
-
-    // if constexpr (!program_settings::use_linearisation) {
-    //     fr z_eval = fr::serialize_from_buffer(&transcript.get_element("z")[0]);
-    //     t_eval += (linear_terms.z_1 * z_eval);
-    //     t_eval += (linear_terms.sigma_last * sigma_evaluations[program_settings::program_width - 1]);
-    // }
 
     fr T0 = lagrange_evals.vanishing_poly.invert();
     t_eval *= T0;
@@ -192,38 +139,24 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
     }
     fr u = fr::serialize_from_buffer(transcript.get_challenge("separator").begin());
 
-    fr batch_evaluation;
-    fr::__copy(t_eval, batch_evaluation);
+    fr batch_evaluation = t_eval;
 
     constexpr size_t nu_offset = program_settings::use_linearisation ? 1 : 0;
     if constexpr (program_settings::use_linearisation) {
         fr linear_eval = fr::serialize_from_buffer(&transcript.get_element("r")[0]);
         T0 = nu_challenges[0] * linear_eval;
         batch_evaluation += T0;
-    } else {
-        fr z_eval = fr::serialize_from_buffer(&transcript.get_element("z")[0]);
-        T0 = z_eval * nu_challenges[2 * program_settings::program_width];
-        batch_evaluation += T0;
-        T0 = nu_challenges[2 * program_settings::program_width - 1] *
-             sigma_evaluations[program_settings::program_width - 1];
-        batch_evaluation += T0;
-    }
+    } 
+
     for (size_t i = 0; i < program_settings::program_width; ++i) {
         T0 = nu_challenges[i + nu_offset] * wire_evaluations[i];
         batch_evaluation += T0;
     }
 
-    for (size_t i = 0; i < program_settings::program_width - 1; ++i) {
-        T0 = nu_challenges[program_settings::program_width + i + nu_offset] * sigma_evaluations[i];
-        batch_evaluation += T0;
-    }
 
     constexpr size_t nu_z_offset = (program_settings::use_linearisation) ? 2 * program_settings::program_width
                                                                          : 2 * program_settings::program_width + 1;
 
-    T0 = nu_challenges[nu_z_offset] * u;
-    T0 *= z_1_shifted_eval;
-    batch_evaluation += T0;
 
     size_t nu_ptr = nu_z_offset + 1;
 
@@ -237,6 +170,7 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
         }
     }
 
+    nu_ptr = program_settings::program_width + nu_offset;
     program_settings::compute_batch_evaluation_contribution(key.get(), batch_evaluation, nu_ptr, transcript);
 
     batch_evaluation.self_neg();

--- a/barretenberg/src/aztec/plonk/proof_system/verifier/verifier.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/verifier/verifier.cpp
@@ -127,8 +127,8 @@ template <typename program_settings> bool VerifierBase<program_settings>::verify
 
     // compute the terms we need to derive R(X)
     plonk_linear_terms linear_terms =
-        compute_linear_terms<barretenberg::fr, transcript::StandardTranscript, program_settings>(transcript,
-                                                                                                 lagrange_evals.l_1);
+        compute_linear_terms<barretenberg::fr, transcript::StandardTranscript, program_settings::program_width>(
+            transcript, lagrange_evals.l_1);
 
     // reconstruct evaluation of quotient polynomial from prover messages
     fr T0;

--- a/barretenberg/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/verifier/verifier.test.cpp
@@ -264,10 +264,16 @@ waffle::Prover generate_test_data(const size_t n)
     key->constraint_selector_ffts.insert({ "q_3_fft", std::move(q_3_fft) });
     key->constraint_selector_ffts.insert({ "q_m_fft", std::move(q_m_fft) });
     key->constraint_selector_ffts.insert({ "q_c_fft", std::move(q_c_fft) });
+
+    std::unique_ptr<waffle::ProverPermutationWidget<3>> permutation_widget =
+        std::make_unique<waffle::ProverPermutationWidget<3>>(key.get(), witness.get());
+
+
     std::unique_ptr<waffle::ProverArithmeticWidget> widget =
         std::make_unique<waffle::ProverArithmeticWidget>(key.get(), witness.get());
 
     waffle::Prover state = waffle::Prover(std::move(key), std::move(witness), create_manifest());
+    state.widgets.emplace_back(std::move(permutation_widget));
     state.widgets.emplace_back(std::move(widget));
     return state;
 }

--- a/barretenberg/src/aztec/plonk/proof_system/widgets/base_widget.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/widgets/base_widget.hpp
@@ -2,6 +2,7 @@
 #include "../../transcript/transcript_wrappers.hpp"
 #include "../types/program_witness.hpp"
 #include "../verification_key/verification_key.hpp"
+#include "../prover/work_queue.hpp"
 #include <ecc/curves/bn254/fr.hpp>
 
 namespace transcript {
@@ -92,7 +93,7 @@ class ProverBaseWidget {
 
     virtual ~ProverBaseWidget() {}
 
-    virtual void compute_round_commitments(transcript::Transcript&, const size_t){};
+    virtual void compute_round_commitments(transcript::Transcript&, const size_t, work_queue&){};
 
     virtual barretenberg::fr compute_quotient_contribution(const barretenberg::fr& alpha_base,
                                                            const transcript::Transcript& transcript) = 0;

--- a/barretenberg/src/aztec/plonk/proof_system/widgets/base_widget.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/widgets/base_widget.hpp
@@ -92,7 +92,7 @@ class ProverBaseWidget {
 
     virtual ~ProverBaseWidget() {}
 
-    virtual void compute_round_commitments(const transcript::Transcript&, const size_t){};
+    virtual void compute_round_commitments(transcript::Transcript&, const size_t){};
 
     virtual barretenberg::fr compute_quotient_contribution(const barretenberg::fr& alpha_base,
                                                            const transcript::Transcript& transcript) = 0;

--- a/barretenberg/src/aztec/plonk/proof_system/widgets/base_widget.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/widgets/base_widget.hpp
@@ -92,6 +92,8 @@ class ProverBaseWidget {
 
     virtual ~ProverBaseWidget() {}
 
+    virtual void compute_round_commitments(const transcript::Transcript&, const size_t){};
+
     virtual barretenberg::fr compute_quotient_contribution(const barretenberg::fr& alpha_base,
                                                            const transcript::Transcript& transcript) = 0;
     virtual barretenberg::fr compute_linear_contribution(const barretenberg::fr& alpha_base,

--- a/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.cpp
@@ -1,0 +1,112 @@
+#include "permutation_widget.hpp"
+#include "../proving_key/proving_key.hpp"
+#include <plonk/transcript/transcript.hpp>
+#include <polynomials/iterate_over_domain.hpp>
+
+using namespace barretenberg;
+
+namespace waffle {
+template <size_t program_width>
+ProverPermutationWidget<program_width>::ProverPermutationWidget(proving_key* input_key, program_witness* input_witness)
+    : ProverBaseWidget(input_key, input_witness)
+{}
+
+template <size_t program_width>
+ProverPermutationWidget<program_width>::ProverPermutationWidget(const ProverPermutationWidget& other)
+    : ProverBaseWidget(other)
+{}
+
+template <size_t program_width>
+ProverPermutationWidget<program_width>::ProverPermutationWidget(ProverPermutationWidget&& other)
+    : ProverBaseWidget(other)
+{}
+
+template <size_t program_width>
+ProverPermutationWidget<program_width>& ProverPermutationWidget<program_width>::operator=(
+    const ProverPermutationWidget& other)
+{
+    ProverBaseWidget::operator=(other);
+    return *this;
+}
+
+template <size_t program_width>
+ProverPermutationWidget<program_width>& ProverPermutationWidget<program_width>::operator=(
+    ProverPermutationWidget&& other)
+{
+    ProverBaseWidget::operator=(other);
+    return *this;
+}
+
+template <size_t program_width>
+void ProverPermutationWidget<program_width>::compute_round_commitments(const transcript::Transcript&, const size_t)
+{}
+
+template <size_t program_width>
+fr ProverPermutationWidget<program_width>::compute_quotient_contribution(const fr& alpha_base,
+                                                                         const transcript::Transcript&)
+{
+    return alpha_base;
+}
+
+template <size_t program_width>
+fr ProverPermutationWidget<program_width>::compute_linear_contribution(const fr& alpha_base,
+                                                                       const transcript::Transcript&,
+                                                                       polynomial&)
+{
+
+    return alpha_base;
+}
+
+template <size_t program_width>
+size_t ProverPermutationWidget<program_width>::compute_opening_poly_contribution(
+    const size_t nu_index, const transcript::Transcript&, barretenberg::fr*, barretenberg::fr*, const bool)
+{
+    return nu_index;
+}
+
+template <size_t program_width>
+void ProverPermutationWidget<program_width>::compute_transcript_elements(transcript::Transcript&, const bool)
+{
+    return;
+}
+
+template class ProverPermutationWidget<3>;
+template class ProverPermutationWidget<4>;
+
+// ###
+
+template <typename Field, typename Group, typename Transcript>
+VerifierPermutationWidget<Field, Group, Transcript>::VerifierPermutationWidget()
+{}
+
+template <typename Field, typename Group, typename Transcript>
+Field VerifierPermutationWidget<Field, Group, Transcript>::compute_quotient_evaluation_contribution(
+    verification_key*, const Field& alpha_base, const Transcript&, Field&, const bool)
+{
+    return alpha_base;
+}
+
+template <typename Field, typename Group, typename Transcript>
+size_t VerifierPermutationWidget<Field, Group, Transcript>::compute_batch_evaluation_contribution(
+    verification_key*, Field&, const size_t nu_index, const Transcript&, const bool)
+{
+    return nu_index;
+};
+
+template <typename Field, typename Group, typename Transcript>
+VerifierBaseWidget::challenge_coefficients<Field> VerifierPermutationWidget<Field, Group, Transcript>::
+    append_scalar_multiplication_inputs(verification_key*,
+                                        const VerifierBaseWidget::challenge_coefficients<Field>& challenge,
+                                        const Transcript&,
+                                        std::vector<Group>&,
+                                        std::vector<Field>&,
+                                        const bool)
+{
+    return challenge;
+}
+
+template class VerifierPermutationWidget<barretenberg::fr,
+                                         barretenberg::g1::affine_element,
+                                         transcript::StandardTranscript>;
+
+} // namespace waffle

--- a/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.cpp
@@ -176,12 +176,13 @@ void ProverPermutationWidget<program_width>::compute_round_commitments(transcrip
         aligned_free(accumulators[(k - 1) * 2 + 1]);
     }
 
-    g1::element Z = barretenberg::scalar_multiplication::pippenger_unsafe(
-        z.get_coefficients(), key->reference_string->get_monomials(), n, key->pippenger_runtime_state);
-    g1::affine_element Z_affine;
-    Z_affine = g1::affine_element(Z);
-
-    transcript.add_element("Z", Z_affine.to_buffer());
+    prover_multiplication_state mul_state{
+        "Z",
+        z.get_coefficients(),
+        key->reference_string->get_monomials(),
+        n,
+    };
+    key->round_multiplications[1].push_back(mul_state);
 }
 
 template <size_t program_width>

--- a/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.cpp
+++ b/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.cpp
@@ -1,11 +1,15 @@
 #include "permutation_widget.hpp"
 #include "../proving_key/proving_key.hpp"
+#include "../public_inputs/public_inputs.hpp"
+
 #include <plonk/transcript/transcript.hpp>
 #include <polynomials/iterate_over_domain.hpp>
+#include <ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp>
 
 using namespace barretenberg;
 
 namespace waffle {
+
 template <size_t program_width>
 ProverPermutationWidget<program_width>::ProverPermutationWidget(proving_key* input_key, program_witness* input_witness)
     : ProverBaseWidget(input_key, input_witness)
@@ -38,14 +42,304 @@ ProverPermutationWidget<program_width>& ProverPermutationWidget<program_width>::
 }
 
 template <size_t program_width>
-void ProverPermutationWidget<program_width>::compute_round_commitments(const transcript::Transcript&, const size_t)
-{}
+void ProverPermutationWidget<program_width>::compute_round_commitments(transcript::Transcript& transcript,
+                                                                       const size_t round_number)
+{
+    if (round_number != 2) {
+        return;
+    }
+    const size_t n = key->n;
+    polynomial& z = key->z;
+
+    fr* accumulators[(program_width == 1) ? 3 : program_width * 2];
+    accumulators[0] = &z[1];
+    accumulators[1] = &key->z_fft[0];
+    accumulators[2] = &key->z_fft[n];
+
+    if constexpr (program_width * 2 > 2) {
+        accumulators[3] = &key->z_fft[n + n];
+    }
+    if constexpr (program_width > 2) {
+        accumulators[4] = &key->z_fft[n + n + n];
+        accumulators[5] = &key->opening_poly[0];
+    }
+    if constexpr (program_width > 3) {
+        accumulators[6] = &key->shifted_opening_poly[0];
+        accumulators[7] = &key->quotient_large[0];
+    }
+    if constexpr (program_width > 4) {
+        accumulators[8] = &key->linear_poly[0];
+        accumulators[9] = &key->quotient_large[n];
+    }
+    if constexpr (program_width > 5) {
+        accumulators[10] = &key->quotient_large[n + n];
+        accumulators[11] = &key->quotient_large[n + n + n];
+    }
+    for (size_t k = 7; k < program_width; ++k) {
+        // we're out of temporary memory!
+        accumulators[(k - 1) * 2] = static_cast<fr*>(aligned_alloc(64, sizeof(fr) * n));
+        accumulators[(k - 1) * 2 + 1] = static_cast<fr*>(aligned_alloc(64, sizeof(fr) * n));
+    }
+
+    fr beta = fr::serialize_from_buffer(transcript.get_challenge("beta").begin());
+    fr gamma = fr::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
+
+    std::array<fr*, program_width> lagrange_base_wires;
+    std::array<fr*, program_width> lagrange_base_sigmas;
+
+    for (size_t i = 0; i < program_width; ++i) {
+        lagrange_base_wires[i] = &key->wire_ffts.at("w_" + std::to_string(i + 1) + "_fft")[0];
+        lagrange_base_sigmas[i] = &key->permutation_selectors_lagrange_base.at("sigma_" + std::to_string(i + 1))[0];
+    }
+
+#ifndef NO_MULTITHREADING
+#pragma omp parallel
+#endif
+    {
+#ifndef NO_MULTITHREADING
+#pragma omp for
+#endif
+        for (size_t j = 0; j < key->small_domain.num_threads; ++j) {
+            fr thread_root = key->small_domain.root.pow(static_cast<uint64_t>(j * key->small_domain.thread_size));
+            fr work_root = thread_root * beta;
+            fr T0;
+            fr wire_plus_gamma;
+            size_t start = j * key->small_domain.thread_size;
+            size_t end = (j + 1) * key->small_domain.thread_size;
+            for (size_t i = start; i < end; ++i) {
+                wire_plus_gamma = gamma + lagrange_base_wires[0][i];
+                accumulators[0][i] = wire_plus_gamma + work_root;
+
+                T0 = lagrange_base_sigmas[0][i] * beta;
+                accumulators[program_width][i] = T0 + wire_plus_gamma;
+
+                for (size_t k = 1; k < program_width; ++k) {
+                    wire_plus_gamma = gamma + lagrange_base_wires[k][i];
+                    T0 = fr::coset_generator(k - 1) * work_root;
+                    accumulators[k][i] = T0 + wire_plus_gamma;
+
+                    T0 = lagrange_base_sigmas[k][i] * beta;
+                    accumulators[k + program_width][i] = T0 + wire_plus_gamma;
+                }
+
+                work_root *= key->small_domain.root;
+            }
+        }
+
+        // step 2: compute the constituent components of Z(X). This is a small multithreading bottleneck, as we have
+        // program_width * 2 non-parallelizable processes
+#ifndef NO_MULTITHREADING
+#pragma omp for
+#endif
+        for (size_t i = 0; i < program_width * 2; ++i) {
+            fr* coeffs = &accumulators[i][0];
+            for (size_t j = 0; j < key->small_domain.size - 1; ++j) {
+                coeffs[j + 1] *= coeffs[j];
+            }
+        }
+
+        // step 3: concatenate together the accumulator elements into Z(X)
+#ifndef NO_MULTITHREADING
+#pragma omp for
+#endif
+        for (size_t j = 0; j < key->small_domain.num_threads; ++j) {
+            const size_t start = j * key->small_domain.thread_size;
+            const size_t end =
+                ((j + 1) * key->small_domain.thread_size) - ((j == key->small_domain.num_threads - 1) ? 1 : 0);
+            fr inversion_accumulator = fr::one();
+            constexpr size_t inversion_index = (program_width == 1) ? 2 : program_width * 2 - 1;
+            fr* inversion_coefficients = &accumulators[inversion_index][0];
+            for (size_t i = start; i < end; ++i) {
+
+                for (size_t k = 1; k < program_width; ++k) {
+                    accumulators[0][i] *= accumulators[k][i];
+                    accumulators[program_width][i] *= accumulators[program_width + k][i];
+                }
+                inversion_coefficients[i] = accumulators[0][i] * inversion_accumulator;
+                inversion_accumulator *= accumulators[program_width][i];
+            }
+            inversion_accumulator = inversion_accumulator.invert();
+            for (size_t i = end - 1; i != start - 1; --i) {
+
+                // N.B. accumulators[0][i] = z[i + 1]
+                // We can avoid fully reducing z[i + 1] as the inverse fft will take care of that for us
+                accumulators[0][i] = inversion_accumulator * inversion_coefficients[i];
+                inversion_accumulator *= accumulators[program_width][i];
+            }
+        }
+    }
+    z[0] = fr::one();
+    z.ifft(key->small_domain);
+    for (size_t k = 7; k < program_width; ++k) {
+        aligned_free(accumulators[(k - 1) * 2]);
+        aligned_free(accumulators[(k - 1) * 2 + 1]);
+    }
+
+    g1::element Z = barretenberg::scalar_multiplication::pippenger_unsafe(
+        z.get_coefficients(), key->reference_string->get_monomials(), n, key->pippenger_runtime_state);
+    g1::affine_element Z_affine;
+    Z_affine = g1::affine_element(Z);
+
+    transcript.add_element("Z", Z_affine.to_buffer());
+}
 
 template <size_t program_width>
 fr ProverPermutationWidget<program_width>::compute_quotient_contribution(const fr& alpha_base,
-                                                                         const transcript::Transcript&)
+                                                                         const transcript::Transcript& transcript)
 {
-    return alpha_base;
+    polynomial& z_fft = key->z_fft;
+
+    // fr alpha = fr::serialize_from_buffer(transcript.get_challenge("alpha").begin());
+    fr neg_alpha = -alpha_base;
+    fr alpha_squared = alpha_base.sqr();
+    fr beta = fr::serialize_from_buffer(transcript.get_challenge("beta").begin());
+    fr gamma = fr::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
+
+    // Our permutation check boils down to two 'grand product' arguments,
+    // that we represent with a single polynomial Z(X).
+    // We want to test that Z(X) has been constructed correctly.
+    // When evaluated at elements of w \in H, the numerator of Z(w) will equal the
+    // identity permutation grand product, and the denominator will equal the copy permutation grand product.
+
+    // The identity that we need to evaluate is: Z(X.w).(permutation grand product) = Z(X).(identity grand product)
+    // i.e. The next element of Z is equal to the current element of Z, multiplied by (identity grand product) /
+    // (permutation grand product)
+
+    // This method computes `Z(X).(identity grand product).{alpha}`.
+    // The random `alpha` is there to ensure our grand product polynomial identity is linearly independent from the
+    // other polynomial identities that we are going to roll into the quotient polynomial T(X).
+
+    // Specifically, we want to compute:
+    // (w_l(X) + \beta.sigma1(X) + \gamma).(w_r(X) + \beta.sigma2(X) + \gamma).(w_o(X) + \beta.sigma3(X) +
+    // \gamma).Z(X).alpha Once we divide by the vanishing polynomial, this will be a degree 3n polynomial.
+
+    // Multiply Z(X) by \alpha^2 when performing fft transform - we get this for free if we roll \alpha^2 into the
+    // multiplicative generator
+    z_fft.coset_fft_with_constant(key->large_domain, alpha_base);
+
+    // We actually want Z(X.w) as well as Z(X)! But that's easy to get. z_fft contains Z(X) evaluated at the 4n'th roots
+    // of unity. So z_fft(i) = Z(w^{i/4}) i.e. z_fft(i + 4) = Z(w^{i/4}.w)
+    // => if virtual term 'foo' contains a 4n fft of Z(X.w), then z_fft(i + 4) = foo(i)
+    // So all we need to do, to get Z(X.w) is to offset indexes to z_fft by 4.
+    // If `i >= 4n  4`, we need to wrap around to the start - so just append the 4 starting elements to the end of z_fft
+    z_fft.add_lagrange_base_coefficient(z_fft[0]);
+    z_fft.add_lagrange_base_coefficient(z_fft[1]);
+    z_fft.add_lagrange_base_coefficient(z_fft[2]);
+    z_fft.add_lagrange_base_coefficient(z_fft[3]);
+
+    std::array<fr*, program_width> wire_ffts;
+    std::array<fr*, program_width> sigma_ffts;
+
+    for (size_t i = 0; i < program_width; ++i) {
+        wire_ffts[i] = &key->wire_ffts.at("w_" + std::to_string(i + 1) + "_fft")[0];
+        sigma_ffts[i] = &key->permutation_selector_ffts.at("sigma_" + std::to_string(i + 1) + "_fft")[0];
+    }
+
+    const polynomial& l_1 = key->lagrange_1;
+
+    // compute our public input component
+    std::vector<barretenberg::fr> public_inputs =
+        barretenberg::fr::from_buffer(transcript.get_element("public_inputs"));
+
+    fr public_input_delta = compute_public_input_delta(public_inputs, beta, gamma, key->small_domain.root);
+    public_input_delta *= alpha_base;
+
+    polynomial& quotient_large = key->quotient_large;
+    // Step 4: Set the quotient polynomial to be equal to
+    // (w_l(X) + \beta.sigma1(X) + \gamma).(w_r(X) + \beta.sigma2(X) + \gamma).(w_o(X) + \beta.sigma3(X) +
+    // \gamma).Z(X).alpha
+#ifndef NO_MULTITHREADING
+#pragma omp parallel for
+#endif
+    for (size_t j = 0; j < key->large_domain.num_threads; ++j) {
+        const size_t start = j * key->large_domain.thread_size;
+        const size_t end = (j + 1) * key->large_domain.thread_size;
+
+        fr work_root = key->large_domain.root.pow(static_cast<uint64_t>(j * key->large_domain.thread_size));
+        work_root *= key->small_domain.generator;
+        // work_root *= fr::coset_generator(0);
+        work_root *= beta;
+
+        fr wire_plus_gamma;
+        fr T0;
+        fr denominator;
+        fr numerator;
+        for (size_t i = start; i < end; ++i) {
+            wire_plus_gamma = gamma + wire_ffts[0][i];
+
+            // Numerator computation
+            numerator = work_root + wire_plus_gamma;
+
+            // Denominator computation
+            denominator = sigma_ffts[0][i] * beta;
+            denominator += wire_plus_gamma;
+
+            for (size_t k = 1; k < program_width; ++k) {
+                wire_plus_gamma = gamma + wire_ffts[k][i];
+                T0 = fr::coset_generator(k - 1) * work_root;
+                T0 += wire_plus_gamma;
+                numerator *= T0;
+
+                T0 = sigma_ffts[k][i] * beta;
+                T0 += wire_plus_gamma;
+                denominator *= T0;
+            }
+
+            numerator *= z_fft[i];
+            denominator *= z_fft[i + 4];
+
+            /**
+             * Permutation bounds check
+             * (Z(X.w) - 1).(\alpha^3).L{n-1}(X) = T(X)Z_H(X)
+             **/
+            // The \alpha^3 term is so that we can subsume this polynomial into the quotient polynomial,
+            // whilst ensuring the term is linearly independent form the other terms in the quotient polynomial
+
+            // We want to verify that Z(X) equals `1` when evaluated at `w_n`, the 'last' element of our multiplicative
+            // subgroup H. But PLONK's 'vanishing polynomial', Z*_H(X), isn't the true vanishing polynomial of subgroup
+            // H. We need to cut a root of unity out of Z*_H(X), specifically `w_n`, for our grand product argument.
+            // When evaluating Z(X) has been constructed correctly, we verify that Z(X.w).(identity permutation product)
+            // = Z(X).(sigma permutation product), for all X \in H. But this relationship breaks down for X = w_n,
+            // because Z(X.w) will evaluate to the *first* element of our grand product argument. The last element of
+            // Z(X) has a dependency on the first element, so the first element cannot have a dependency on the last
+            // element.
+
+            // TODO: With the reduction from 2 Z polynomials to a single Z(X), the above no longer applies
+            // TODO: Fix this to remove the (Z(X.w) - 1).L_{n-1}(X) check
+
+            // To summarise, we can't verify claims about Z(X) when evaluated at `w_n`.
+            // But we can verify claims about Z(X.w) when evaluated at `w_{n-1}`, which is the same thing
+
+            // To summarise the summary: If Z(w_n) = 1, then (Z(X.w) - 1).L_{n-1}(X) will be divisible by Z_H*(X)
+            // => add linearly independent term (Z(X.w) - 1).(\alpha^3).L{n-1}(X) into the quotient polynomial to check
+            // this
+
+            // z_fft already contains evaluations of Z(X).(\alpha^2)
+            // at the (2n)'th roots of unity
+            // => to get Z(X.w) instead of Z(X), index element (i+2) instead of i
+            T0 = z_fft[i + 4] - public_input_delta; // T0 = (Z(X.w) - (delta)).(\alpha^2)
+            T0 *= alpha_base;                       // T0 = (Z(X.w) - (delta)).(\alpha^3)
+            T0 *= l_1[i + 8];                       // T0 = (Z(X.w)-delta).(\alpha^3).L{n-1}
+            numerator += T0;
+
+            // Step 2: Compute (Z(X) - 1).(\alpha^4).L1(X)
+            // We need to verify that Z(X) equals `1` when evaluated at the first element of our subgroup H
+            // i.e. Z(X) starts at 1 and ends at 1
+            // The `alpha^4` term is so that we can add this as a linearly independent term in our quotient polynomial
+            T0 = z_fft[i] + neg_alpha; // T0 = (Z(X) - 1).(\alpha^2)
+            T0 *= alpha_squared;       // T0 = (Z(X) - 1).(\alpha^4)
+            T0 *= l_1[i];              // T0 = (Z(X) - 1).(\alpha^2).L1(X)
+            numerator += T0;
+
+            // Combine into quotient polynomial
+            T0 = numerator - denominator;
+            quotient_large[i] = T0;
+
+            // Update our working root of unity
+            work_root *= key->large_domain.root;
+        }
+    }
+    return alpha_base.sqr().sqr();
 }
 
 template <size_t program_width>

--- a/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#include "base_widget.hpp"
+
+namespace waffle {
+template <typename Field, typename Group, typename Transcript> class VerifierPermutationWidget {
+  public:
+    VerifierPermutationWidget();
+
+    static Field compute_quotient_evaluation_contribution(verification_key*,
+                                                          const Field& alpha_base,
+                                                          const Transcript& transcript,
+                                                          Field& t_eval,
+                                                          const bool use_linearisation);
+
+    static VerifierBaseWidget::challenge_coefficients<Field> append_scalar_multiplication_inputs(
+        verification_key*,
+        const VerifierBaseWidget::challenge_coefficients<Field>& challenge,
+        const Transcript& transcript,
+        std::vector<Group>& points,
+        std::vector<Field>& scalars,
+        const bool use_linearisation);
+
+    static size_t compute_batch_evaluation_contribution(verification_key*,
+                                                        Field& batch_eval,
+                                                        const size_t nu_index,
+                                                        const Transcript& transcript,
+                                                        const bool use_linearisation);
+};
+
+extern template class VerifierPermutationWidget<barretenberg::fr,
+                                                barretenberg::g1::affine_element,
+                                                transcript::StandardTranscript>;
+
+template <size_t program_width> class ProverPermutationWidget : public ProverBaseWidget {
+  public:
+    ProverPermutationWidget(proving_key*, program_witness*);
+    ProverPermutationWidget(const ProverPermutationWidget& other);
+    ProverPermutationWidget(ProverPermutationWidget&& other);
+    ProverPermutationWidget& operator=(const ProverPermutationWidget& other);
+    ProverPermutationWidget& operator=(ProverPermutationWidget&& other);
+
+    void compute_round_commitments(const transcript::Transcript& transcript, const size_t round_number) override;
+
+    barretenberg::fr compute_quotient_contribution(const barretenberg::fr& alpha_base,
+                                                   const transcript::Transcript& transcript) override;
+    barretenberg::fr compute_linear_contribution(const barretenberg::fr& alpha_base,
+                                                 const transcript::Transcript& transcript,
+                                                 barretenberg::polynomial& r) override;
+    size_t compute_opening_poly_contribution(const size_t nu_index,
+                                             const transcript::Transcript&,
+                                             barretenberg::fr*,
+                                             barretenberg::fr*,
+                                             const bool) override;
+
+    void compute_transcript_elements(transcript::Transcript&, const bool) override;
+};
+
+extern template class ProverPermutationWidget<3>;
+extern template class ProverPermutationWidget<4>;
+
+} // namespace waffle

--- a/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.hpp
@@ -39,7 +39,9 @@ template <size_t program_width> class ProverPermutationWidget : public ProverBas
     ProverPermutationWidget& operator=(const ProverPermutationWidget& other);
     ProverPermutationWidget& operator=(ProverPermutationWidget&& other);
 
-    void compute_round_commitments(transcript::Transcript& transcript, const size_t round_number) override;
+    void compute_round_commitments(transcript::Transcript& transcript,
+                                   const size_t round_number,
+                                   work_queue& queue) override;
 
     barretenberg::fr compute_quotient_contribution(const barretenberg::fr& alpha_base,
                                                    const transcript::Transcript& transcript) override;

--- a/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.hpp
+++ b/barretenberg/src/aztec/plonk/proof_system/widgets/permutation_widget.hpp
@@ -39,7 +39,7 @@ template <size_t program_width> class ProverPermutationWidget : public ProverBas
     ProverPermutationWidget& operator=(const ProverPermutationWidget& other);
     ProverPermutationWidget& operator=(ProverPermutationWidget&& other);
 
-    void compute_round_commitments(const transcript::Transcript& transcript, const size_t round_number) override;
+    void compute_round_commitments(transcript::Transcript& transcript, const size_t round_number) override;
 
     barretenberg::fr compute_quotient_contribution(const barretenberg::fr& alpha_base,
                                                    const transcript::Transcript& transcript) override;

--- a/barretenberg/src/aztec/plonk/transcript/transcript_wrappers.cpp
+++ b/barretenberg/src/aztec/plonk/transcript/transcript_wrappers.cpp
@@ -11,6 +11,11 @@ barretenberg::fr StandardTranscript::get_field_element(const std::string& elemen
     return barretenberg::fr::serialize_from_buffer(&(get_element(element_name))[0]);
 }
 
+std::vector<barretenberg::fr> StandardTranscript::get_field_element_vector(const std::string& element_name) const
+{
+    return barretenberg::fr::from_buffer(get_element(element_name));
+}
+
 barretenberg::fr StandardTranscript::get_challenge_field_element(const std::string& challenge_name,
                                                                  const size_t idx) const
 {

--- a/barretenberg/src/aztec/plonk/transcript/transcript_wrappers.hpp
+++ b/barretenberg/src/aztec/plonk/transcript/transcript_wrappers.hpp
@@ -22,6 +22,8 @@ class StandardTranscript : public Transcript {
 
     barretenberg::fr get_field_element(const std::string& element_name) const;
 
+    std::vector<barretenberg::fr> get_field_element_vector(const std::string& element_name) const;
+
     barretenberg::fr get_challenge_field_element(const std::string& challenge_name, const size_t idx = 0) const;
 };
 

--- a/barretenberg/src/aztec/plonk_bench/plonk.bench.cpp
+++ b/barretenberg/src/aztec/plonk_bench/plonk.bench.cpp
@@ -102,37 +102,4 @@ void verify_proofs_bench(State& state) noexcept
 }
 BENCHMARK(verify_proofs_bench)->RangeMultiplier(2)->Range(START, MAX_GATES);
 
-void compute_wire_coefficients(State& state) noexcept
-{
-    for (auto _ : state) {
-        size_t idx = static_cast<size_t>(numeric::get_msb((uint64_t)state.range(0))) -
-                     static_cast<size_t>(numeric::get_msb(START));
-        provers[idx].reset();
-        provers[idx].init_quotient_polynomials();
-        provers[idx].compute_wire_coefficients();
-    }
-}
-BENCHMARK(compute_wire_coefficients)->RangeMultiplier(2)->Range(START, MAX_GATES);
-
-void compute_wire_commitments(State& state) noexcept
-{
-    for (auto _ : state) {
-        size_t idx = static_cast<size_t>(numeric::get_msb((uint64_t)state.range(0))) -
-                     static_cast<size_t>(numeric::get_msb(START));
-        provers[idx].reset();
-        provers[idx].compute_wire_commitments();
-    }
-}
-BENCHMARK(compute_wire_commitments)->RangeMultiplier(2)->Range(START, MAX_GATES);
-
-void compute_z_coefficients(State& state) noexcept
-{
-    for (auto _ : state) {
-        size_t idx = static_cast<size_t>(numeric::get_msb((uint64_t)state.range(0))) -
-                     static_cast<size_t>(numeric::get_msb(START));
-        provers[idx].compute_z_coefficients();
-    }
-}
-BENCHMARK(compute_z_coefficients)->RangeMultiplier(2)->Range(START, MAX_GATES);
-
 BENCHMARK_MAIN();

--- a/barretenberg/src/aztec/stdlib/merkle_tree/leveldb_store.test.cpp
+++ b/barretenberg/src/aztec/stdlib/merkle_tree/leveldb_store.test.cpp
@@ -4,10 +4,14 @@
 #include <gtest/gtest.h>
 #include <leveldb/db.h>
 #include <stdlib/types/turbo.hpp>
-#include <sys/random.h>
+#include <numeric/random/engine.hpp>
 
 using namespace barretenberg;
 using namespace plonk::stdlib::merkle_tree;
+
+namespace {
+auto& engine = numeric::random::get_debug_engine();
+}
 
 static std::vector<std::string> VALUES = []() {
     std::vector<std::string> values(1024);
@@ -179,8 +183,7 @@ TEST(stdlib_merkle_tree, test_leveldb_update_1024_random)
 
     for (size_t i = 0; i < 1024; i++) {
         LevelDbStore::index_t index;
-        int got_entropy = getentropy((void*)&index, sizeof(index));
-        ASSERT(got_entropy == 0);
+        index = engine.get_random_uint128();
         db.update_element(index, VALUES[i]);
         entries.push_back(std::make_pair(index, VALUES[i]));
     }

--- a/barretenberg/src/aztec/stdlib/recursion/verifier.hpp
+++ b/barretenberg/src/aztec/stdlib/recursion/verifier.hpp
@@ -132,7 +132,7 @@ recursion_output<Group> verify_proof(Composer* context,
     lagrange_evaluations<Composer> lagrange_evals = get_lagrange_evaluations(z_challenge, key->domain);
 
     plonk_linear_terms linear_terms =
-        compute_linear_terms<field_t, Transcript, program_settings>(transcript, lagrange_evals.l_1);
+        compute_linear_terms<field_t, Transcript, program_settings::program_width>(transcript, lagrange_evals.l_1);
 
     // reconstruct evaluation of quotient polynomial from prover messages
     field_t T0;


### PR DESCRIPTION
this PR moves the prover/verifier logic associated with PLONK's copy constraints, into a specialized widget.  

the rationale behind this, is that our lookup table sub-protocol also relies on randomized constraints, permutations and grand product arguments. Moving the copy constraint functionality into a discrete widget gives us the flexibility to make modifications to PLONK's permutation argument, without requiring a refactor of the underlying proving system logic.  

This PR also implements a simple work queue system, that is used in the prover algorithms. This should be helpful in execution environments where multithreading can only be leveraged by spawning distinct processes. Of particular concern is WASM and in-browser proof construction. The majority of browsers have disabled WASM multithreading for security reasons.  

The rationale behind the work queue, is that the internals of the work queue can be re-implemented by a higher-level program that includes barretenberg as a dependency, allowing for simple parallelism that is external to barretenberg (e.g. spawning web workers to execute jobs in the work queue)