### PR TITLE
runtime_state and reference_string bug fix

### DIFF
--- a/barretenberg/src/aztec/ecc/curves/bn254/scalar_multiplication/runtime_states.cpp
+++ b/barretenberg/src/aztec/ecc/curves/bn254/scalar_multiplication/runtime_states.cpp
@@ -20,7 +20,8 @@ pippenger_runtime_state::pippenger_runtime_state(const size_t num_initial_points
 #else
     const size_t num_threads = 1;
 #endif
-    point_schedule = (uint64_t*)(aligned_alloc(64, static_cast<size_t>(num_points) * num_rounds * sizeof(uint64_t)));
+    const size_t prefetch_overflow = 16 * num_threads;
+    point_schedule = (uint64_t*)(aligned_alloc(64, (static_cast<size_t>(num_points) * num_rounds + prefetch_overflow) * sizeof(uint64_t)));
     skew_table = (bool*)(aligned_alloc(64, static_cast<size_t>(num_points) * sizeof(bool)));
     buckets = (g1::element*)(aligned_alloc(64, num_threads * (num_buckets + num_threads) * sizeof(g1::element)));
     round_counts = (uint64_t*)(aligned_alloc(32, MAX_NUM_ROUNDS * sizeof(uint64_t)));

--- a/barretenberg/src/aztec/plonk/reference_string/file_reference_string.cpp
+++ b/barretenberg/src/aztec/plonk/reference_string/file_reference_string.cpp
@@ -21,8 +21,15 @@ VerifierFileReferenceString::~VerifierFileReferenceString()
 
 FileReferenceString::FileReferenceString(const size_t num_points, std::string const& path)
 {
+#ifndef NO_MULTITHREADING
+    const size_t num_threads = static_cast<size_t>(omp_get_max_threads());
+#else
+    const size_t num_threads = 1;
+#endif
+    const size_t prefetch_overflow = 16 * num_threads;
+
     monomials = (barretenberg::g1::affine_element*)(aligned_alloc(
-        64, sizeof(barretenberg::g1::affine_element) * (2 * num_points + 2)));
+        64, sizeof(barretenberg::g1::affine_element) * (2 * num_points + prefetch_overflow)));
     barretenberg::io::read_transcript_g1(monomials, num_points, path);
     barretenberg::scalar_multiplication::generate_pippenger_point_table(monomials, monomials, num_points);
 }

--- a/barretenberg/src/aztec/plonk/reference_string/file_reference_string.cpp
+++ b/barretenberg/src/aztec/plonk/reference_string/file_reference_string.cpp
@@ -3,6 +3,10 @@
 #include <ecc/curves/bn254/scalar_multiplication/scalar_multiplication.hpp>
 #include <srs/io.hpp>
 
+#ifndef NO_MULTITHREADING
+#include <omp.h>
+#endif
+
 namespace waffle {
 
 VerifierFileReferenceString::VerifierFileReferenceString(std::string const& path)

--- a/barretenberg/src/aztec/plonk/reference_string/mem_reference_string.cpp
+++ b/barretenberg/src/aztec/plonk/reference_string/mem_reference_string.cpp
@@ -5,6 +5,10 @@
 #include <srs/io.hpp>
 #include <sstream>
 
+#ifndef NO_MULTITHREADING
+#include <omp.h>
+#endif
+
 namespace waffle {
 
 VerifierMemReferenceString::VerifierMemReferenceString(char const* buffer)
@@ -25,8 +29,14 @@ VerifierMemReferenceString::~VerifierMemReferenceString()
 
 MemReferenceString::MemReferenceString(const size_t num_points, char const* buffer, size_t)
 {
+#ifndef NO_MULTITHREADING
+    const size_t num_threads = static_cast<size_t>(omp_get_max_threads());
+#else
+    const size_t num_threads = 1;
+#endif
+    const size_t prefetch_overflow = 16 * num_threads;
     monomials = (barretenberg::g1::affine_element*)(aligned_alloc(
-        64, sizeof(barretenberg::g1::affine_element) * (2 * num_points + 2)));
+        64, sizeof(barretenberg::g1::affine_element) * (2 * num_points + prefetch_overflow)));
 
     monomials[0] = barretenberg::g1::affine_one;
 


### PR DESCRIPTION
we prefetch memory in pippenger,
data structures have been updated to allocate
enough memory to accomodate for this prefetching