### PR TITLE
fix typo

### DIFF
--- a/barretenberg/README.md
+++ b/barretenberg/README.md
@@ -30,7 +30,7 @@ export LD_LIBRARY_PATH="/usr/local/clang_9.0.0/lib:$LD_LIBRARY_PATH"
 ```
 brew install cmake
 brew install llvm
-brew instal libomp
+brew install libomp
 ```
 
 ### Getting started


### PR DESCRIPTION
Forgot an `l` for install in `brew install libomp`. Very tiny but it was just bothering me.